### PR TITLE
Enforce canonical traceability checks, update CLI script usage, add roadmap and spec updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A spec-first CLI tool where **user journeys are requirements** and **BDD scenari
 
 ```bash
 # Initialize in your project
-npx udd init
+npm run udd -- init
 
 # Sync journeys to scenarios
-udd sync
+npm run udd -- sync
 
 # Check status
-udd status
+npm run udd -- status
 ```
 
 ## How It Works
@@ -51,6 +51,8 @@ tests/                            # Agent-generated
 ```
 
 ## Commands
+
+> Tip: If `udd` is not globally linked, use `npm run udd -- <command>` from the repo root.
 
 | Command | Purpose |
 |---------|---------|

--- a/docs/project/ROADMAP_TRACKER_2026-05-11.md
+++ b/docs/project/ROADMAP_TRACKER_2026-05-11.md
@@ -1,0 +1,27 @@
+# Goal Gap Roadmap Tracker (2026-05-11)
+
+This tracker converts the prioritized recommendations from `GOAL_GAP_ASSESSMENT_2026-05-11.md` into explicitly owned, stateful work items.
+
+## Status Legend
+
+- `todo`: planned and not started
+- `in_progress`: actively being implemented
+- `blocked`: cannot proceed until dependency/decision is resolved
+- `done`: completed and merged
+
+## Work Items
+
+| ID | Priority | Item | Status | Owner | Depends On | Exit Criteria |
+| --- | --- | --- | --- | --- | --- | --- |
+| GG-01 | P0 | Define/enforce canonical traceability graph (objective → use case → scenario → e2e test) | in_progress | engineering | none | `udd lint` fails on broken trace links and unlinked scenarios |
+| GG-02 | P0 | Add objective-aware status rollups | todo | engineering | GG-01 | `udd status --json` includes objective health/progress |
+| GG-03 | P1 | Unify spec structure or codify dual-mode operation | todo | product+engineering | GG-01 | Canonical mode documented and lint-enforced |
+| GG-04 | P1 | Tighten developer/runtime onboarding | in_progress | engineering | none | Documented command path works in CI + local bootstrap |
+| GG-05 | P1 | Clarify command generation contracts | todo | docs | GG-03 | Commands have explicit generated outputs and examples |
+| GG-06 | P2 | Add management-facing reports | todo | engineering | GG-02 | Machine-readable and markdown planning reports available |
+
+## Update Process
+
+1. Update `Status`, `Owner`, and `Depends On` as work changes.
+2. Add links to implementing PRs beside the relevant row when available.
+3. Keep this file in sync with status output changes to preserve planning visibility.

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
 		"setup": "npm install && chmod +x bin/udd && npm link",
 		"test": "vitest run",
 		"test:ui": "vitest --ui",
-		"lint": "tsx bin/udd.ts lint",
-		"status": "tsx bin/udd.ts status",
+		"lint": "npm run udd -- lint",
+		"status": "npm run udd -- status",
 		"check": "biome check .",
 		"check:fix": "biome check --write .",
 		"prepare": "husky",
-		"postinstall": "tsx scripts/patch-vitest-cucumber.ts"
+		"postinstall": "tsx scripts/patch-vitest-cucumber.ts",
+		"udd": "tsx bin/udd.ts"
 	},
 	"lint-staged": {
 		"**/*.ts": [

--- a/specs/use-cases/validate_specs.yml
+++ b/specs/use-cases/validate_specs.yml
@@ -11,3 +11,10 @@ outcomes:
   - description: "Invalid specs report errors"
     scenarios:
       - "udd/cli/lint_invalid_specs"
+
+  - description: "Validation guidance can be discovered for spec authoring"
+    scenarios:
+      - "udd/cli/validation/discover_feature"
+  - description: "Scenario completeness checks can be validated"
+    scenarios:
+      - "udd/cli/validation/validate_completeness"

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -47,6 +47,7 @@ export async function validateSpecs(): Promise<ValidationResult> {
 	const useCaseIds = new Set<string>();
 	// Track scenarios referenced by use cases and requirements so we can detect orphans
 	const referencedScenarios = new Set<string>();
+	const normalizedFeatureScenarios = new Set<string>();
 	for (const file of useCaseFiles) {
 		try {
 			const content = await fs.readFile(path.join(rootDir, file), "utf-8");
@@ -155,6 +156,43 @@ export async function validateSpecs(): Promise<ValidationResult> {
 	});
 	if (scenarioFiles.length === 0) {
 		errors.push("No scenario files found");
+	}
+
+	for (const file of scenarioFiles) {
+		const relativeToFeatures = file
+			.replace(/^specs\/features\//, "")
+			.replace(/\.feature$/, "");
+		normalizedFeatureScenarios.add(relativeToFeatures);
+	}
+
+	// 6. Enforce canonical traceability chain: objective (VISION use_cases) -> use case -> scenario -> e2e test
+	for (const scenarioPath of referencedScenarios) {
+		if (!normalizedFeatureScenarios.has(scenarioPath)) {
+			errors.push(
+				`Traceability gap: referenced scenario not found in canonical features path: ${scenarioPath}`,
+			);
+		}
+	}
+
+	for (const scenarioPath of normalizedFeatureScenarios) {
+		if (!referencedScenarios.has(scenarioPath)) {
+			errors.push(
+				`Traceability gap: scenario missing use-case/requirement link: ${scenarioPath}`,
+			);
+		}
+
+		const scenarioSlug = scenarioPath.split("/").pop();
+		if (!scenarioSlug) {
+			continue;
+		}
+
+		const testPattern = `tests/e2e/**/${scenarioSlug}.e2e.test.ts`;
+		const matchingTests = await glob(testPattern, { cwd: rootDir });
+		if (matchingTests.length === 0) {
+			errors.push(
+				`Traceability gap: scenario missing e2e test: ${scenarioPath}`,
+			);
+		}
 	}
 
 	return {


### PR DESCRIPTION
### Motivation

- Enforce a canonical traceability chain (objective → use case → scenario → e2e test) to detect orphaned or unlinked artifacts and surface clear errors.
- Make the local CLI easier to run without global linking by surfacing an `npm` wrapper script and updating docs to a reproducible invocation.
- Capture near-term roadmap work items for closing goal gaps and traceability enforcement.

### Description

- Updated `src/lib/validator.ts` to build a normalized set of feature scenario paths, validate referenced scenarios exist in `specs/features`, require each feature scenario to be linked from a use-case, and require a matching e2e test file (`tests/e2e/**/<slug>.e2e.test.ts`), emitting clear `Traceability gap:` errors when checks fail.
- Added `normalizedFeatureScenarios` and comparisons against `referencedScenarios` and test discovery using `glob` in `validateSpecs`.
- Adjusted CLI ergonomics in `package.json` by adding an `udd` script (`tsx bin/udd.ts`) and changing `lint` and `status` to invoke the CLI via `npm run udd -- <command>`.
- Updated `README.md` to recommend `npm run udd -- <command>` examples and added a usage tip for non-global installs.
- Added a project tracker document `docs/project/ROADMAP_TRACKER_2026-05-11.md` with prioritized work items and statuses.
- Extended `specs/use-cases/validate_specs.yml` to include new outcomes for validation guidance discovery and completeness checks.

### Testing

- Ran unit tests with `npm test` (Vitest) and the test suite completed successfully.
- Ran the linter via `npm run lint` to validate spec scaffolding and command wiring and it passed without errors.
- Exercised the validator by running the validation flow (`npm run udd -- validate`), which reported expected traceability error messages for intentionally incomplete fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e805c358832c9c71784f9d1a672b)