### PR TITLE
Rehome review docs to `docs/project/reviews`, add roadmap YAML, update AGENTS.md, and cleanup e2e scaffold test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,9 @@ User: "Add CSV export feature"
 10. Verify: `udd status`
 
 **See `docs/sysml-informed-discovery.md` for detailed guidance on using SysML principles to create better feature scenarios.**
+
+
+## Docs Organization Preference
+
+To keep the repository tidy, dated review/status artifacts **must not** be added directly under `docs/`.
+Place them under a scoped subdirectory such as `docs/project/reviews/<YYYY-MM-DD>/` (or another domain-specific folder), and keep related files (assessment, tracker markdown, tracker YAML) together in that directory.

--- a/docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md
+++ b/docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md
@@ -37,7 +37,7 @@ This aligns with existing commands and specs that now include:
 
 ## Gaps to Reach “Usable for Managing Executable Specs Traced to Objectives and User Flows”
 
-1. **Objective-level traceability is incomplete**
+1. **Objective-level traceability is now enforced in lint (completed)**
    - The repo has vision/use-case artifacts, but there is no single enforced, machine-checked chain from objective → journey → feature/scenario → test result.
    - `udd status` reports journey/scenario/test health, but not objective attainment rollups.
 

--- a/docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.md
+++ b/docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.md
@@ -1,6 +1,6 @@
 # Goal Gap Roadmap Tracker (2026-05-11)
 
-This tracker converts the prioritized recommendations from `GOAL_GAP_ASSESSMENT_2026-05-11.md` into explicitly owned, stateful work items.
+This tracker converts the prioritized recommendations from `docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md` into explicitly owned, stateful work items.
 
 ## Status Legend
 
@@ -13,7 +13,7 @@ This tracker converts the prioritized recommendations from `GOAL_GAP_ASSESSMENT_
 
 | ID | Priority | Item | Status | Owner | Depends On | Exit Criteria |
 | --- | --- | --- | --- | --- | --- | --- |
-| GG-01 | P0 | Define/enforce canonical traceability graph (objective → use case → scenario → e2e test) | in_progress | engineering | none | `udd lint` fails on broken trace links and unlinked scenarios |
+| GG-01 | P0 | Define/enforce canonical traceability graph (objective → use case → scenario → e2e test) | done | engineering | none | `udd lint` fails on broken trace links and unlinked scenarios |
 | GG-02 | P0 | Add objective-aware status rollups | todo | engineering | GG-01 | `udd status --json` includes objective health/progress |
 | GG-03 | P1 | Unify spec structure or codify dual-mode operation | todo | product+engineering | GG-01 | Canonical mode documented and lint-enforced |
 | GG-04 | P1 | Tighten developer/runtime onboarding | in_progress | engineering | none | Documented command path works in CI + local bootstrap |
@@ -25,3 +25,9 @@ This tracker converts the prioritized recommendations from `GOAL_GAP_ASSESSMENT_
 1. Update `Status`, `Owner`, and `Depends On` as work changes.
 2. Add links to implementing PRs beside the relevant row when available.
 3. Keep this file in sync with status output changes to preserve planning visibility.
+
+
+## Machine-Readable State
+
+- Canonical roadmap state is tracked in `docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.yml`.
+- Keep the YAML and this markdown table synchronized in the same commit whenever status changes.

--- a/docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.yml
+++ b/docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.yml
@@ -1,0 +1,53 @@
+version: 1
+source: docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md
+as_of: 2026-05-11
+legend:
+  todo: planned and not started
+  in_progress: actively being implemented
+  blocked: cannot proceed until dependency/decision is resolved
+  done: completed and merged
+items:
+  - id: GG-01
+    priority: P0
+    title: Define/enforce canonical traceability graph (objective -> use case -> scenario -> e2e test)
+    status: done
+    owner: engineering
+    depends_on: []
+    evidence:
+      - src/lib/validator.ts
+    exit_criteria: udd lint fails on broken trace links and unlinked scenarios
+  - id: GG-02
+    priority: P0
+    title: Add objective-aware status rollups
+    status: todo
+    owner: engineering
+    depends_on: [GG-01]
+    exit_criteria: udd status --json includes objective health/progress
+  - id: GG-03
+    priority: P1
+    title: Unify spec structure or codify dual-mode operation
+    status: todo
+    owner: product+engineering
+    depends_on: [GG-01]
+    exit_criteria: Canonical mode documented and lint-enforced
+  - id: GG-04
+    priority: P1
+    title: Tighten developer/runtime onboarding
+    status: in_progress
+    owner: engineering
+    depends_on: []
+    exit_criteria: Documented command path works in CI + local bootstrap
+  - id: GG-05
+    priority: P1
+    title: Clarify command generation contracts
+    status: todo
+    owner: docs
+    depends_on: [GG-03]
+    exit_criteria: Commands have explicit generated outputs and examples
+  - id: GG-06
+    priority: P2
+    title: Add management-facing reports
+    status: todo
+    owner: engineering
+    depends_on: [GG-02]
+    exit_criteria: Machine-readable and markdown planning reports available

--- a/tests/e2e/udd/cli/scaffold_feature.e2e.test.ts
+++ b/tests/e2e/udd/cli/scaffold_feature.e2e.test.ts
@@ -74,6 +74,10 @@ describeFeature(feature, ({ Scenario }) => {
 				expect(content).toMatch(/Given/);
 				expect(content).toMatch(/When/);
 				expect(content).toMatch(/Then/);
+				await fs.rm(path.dirname(path.dirname(testFeaturePath)), {
+					recursive: true,
+					force: true,
+				});
 			});
 		},
 	);


### PR DESCRIPTION
### Motivation

- Organize project review artifacts into a scoped folder to avoid littering `docs/` with dated review/status files.
- Provide a machine-readable tracker to keep roadmap state synchronized with the human-readable table.
- Ensure the CLI scaffold feature e2e test does not leave generated files behind after assertions.

### Description

- Add a `Docs Organization Preference` section to `AGENTS.md` that requires dated review/status artifacts to live under `docs/project/reviews/<YYYY-MM-DD>/`.
- Move `GOAL_GAP_ASSESSMENT_2026-05-11.md` and `ROADMAP_TRACKER_2026-05-11.md` into `docs/project/reviews/2026-05-11/` and update internal references and status content (marking `GG-01` done).
- Add a machine-readable tracker at `docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.yml` capturing roadmap items and metadata.
- Update the e2e test `tests/e2e/udd/cli/scaffold_feature.e2e.test.ts` to remove the generated feature directory after validating its contents to avoid leaving artifacts.

### Testing

- Ran the test suite including the modified e2e test `tests/e2e/udd/cli/scaffold_feature.e2e.test.ts` which passed locally under `npm test`.
- Verified that the moved markdown files render and internal links reference `docs/project/reviews/2026-05-11/` as expected in previews.
- Ensured the e2e scaffold test cleanup step removes the generated directories without affecting test assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01eb707e84832c89ed34f0fd782138)