### PR TITLE
[codex] add shared agent integration contract

### DIFF
--- a/.opencode/command/udd/iterate.md
+++ b/.opencode/command/udd/iterate.md
@@ -28,7 +28,7 @@ Example injection (rendered from JSON):
 ```
 ## Current Project Status
 
-**Phase**: 3 - OpenCode Integration
+**Phase**: 3 - Agent Integration
 **Roadmap (next steps)**: sync journeys → generate scenarios → implement failing scenarios
 **Dirty Tests**: 46 (run `udd test` to refresh results)
 **Drift Status**: ⚠️ 31 issues detected (run `udd doctor` for diagnostics or `udd doctor --fix` to attempt automated remediation)

--- a/.opencode/command/udd/status.md
+++ b/.opencode/command/udd/status.md
@@ -19,7 +19,7 @@ Example:
 
 ```
 Project: udd
-Phase: 3 - OpenCode Integration
+Phase: 3 - Agent Integration
 Journeys: 12 (2 changed)
 Scenarios: 48 total (5 failing, 3 missing, 2 stale)
 Dirty tests: 46

--- a/docs/architecture/concept-mappings.md
+++ b/docs/architecture/concept-mappings.md
@@ -254,7 +254,7 @@ current_phase: opencode-integration
 
 phases:
   - id: opencode-integration
-    name: "OpenCode Integration"
+    name: "Agent Integration"
     status: active
     use_cases:
       - id: orchestrated_iteration
@@ -686,4 +686,3 @@ TEST: create_task.e2e.test.ts
 | Scenario | `specs/features/*.feature` | E2E Tests | Acceptance Criteria |
 | Roadmap | `specs/roadmap.yml` | Use Cases (assigns phase) | Life Cycle Plan |
 | Test | `tests/e2e/*.test.ts` | Scenarios | Verification |
-

--- a/docs/architecture/phase3-final-state-vision.md
+++ b/docs/architecture/phase3-final-state-vision.md
@@ -1,10 +1,10 @@
 # Phase 3 Completion: Final State Vision
 
-This document describes the complete, correct state of the UDD project after Phase 3 (OpenCode Integration) is fully implemented and validated.
+This document describes the complete, correct state of the UDD project after Phase 3 (Agent Integration) is fully implemented and validated.
 
 ## Executive Summary
 
-Phase 3 delivers **OpenCode Integration** - the ability for AI agents to autonomously drive UDD workflows. The project now has:
+Phase 3 delivers **Agent Integration** - the ability for AI agents to autonomously drive UDD workflows through shared contracts and runtime-specific adapters. The project now has:
 
 - ✅ **Clear phase alignment**: All Phase 3 features tagged @phase:3
 - ✅ **Proper roadmap**: specs/roadmap.yml drives timing
@@ -135,9 +135,9 @@ phases:
     description: "Research workflow, tech spec scaffolding"
     
   - id: opencode-integration
-    name: "OpenCode Integration"
+    name: "Agent Integration"
     status: active
-    description: "Custom tools, orchestrator plugin, JSON output"
+    description: "Shared integration contracts, adapter tools, orchestrator plugin, JSON output"
     use_cases:
       - id: orchestrated_iteration
         capability: autonomous-development
@@ -385,10 +385,10 @@ User Journeys:
   Validate Phase Consistency ✓             2/2 outcomes satisfied
 
 Roadmap:
-  Current Phase: 3 - OpenCode Integration
+  Current Phase: 3 - Agent Integration
     Phase 1: Core CLI & Validation ✓
     Phase 2: Research & Tech Specs ✓
-  → Phase 3: OpenCode Integration (ACTIVE)
+  → Phase 3: Agent Integration (ACTIVE)
     Phase 4: Agent Intelligence (planned)
     Phase 5: Advanced Workflows (planned)
 
@@ -566,7 +566,7 @@ $ cd udd && npm install
 # Verify Phase 3 complete
 $ udd status
 ✓ All journeys satisfied
-✓ Current Phase: 3 - OpenCode Integration (COMPLETE)
+✓ Current Phase: 3 - Agent Integration (COMPLETE)
 
 # Run orchestration
 $ udd orchestrate --max-iterations 10 --json

--- a/docs/process/udd-agent-operations.md
+++ b/docs/process/udd-agent-operations.md
@@ -2,7 +2,28 @@
 
 Purpose
 -------
-This playbook documents the agent operations workflow for UDD (User Driven Development). It defines the agent workflow, handoff protocol, and traceability update procedures so agent work is consistent, auditable, and verifiable.
+This playbook documents the agent operations workflow for UDD (User Driven Development). It defines the shared agent workflow, handoff protocol, and traceability update procedures so Codex, OpenCode, and future adapters behave consistently.
+
+Shared integration contracts live under `integrations/shared/`. Adapter-specific
+details live under `integrations/opencode/`, `integrations/codex/`, or the
+runtime-native adapter directory.
+
+Goal command contract
+---------------------
+Use `/goal goals/<file>.md` for goal-file execution. This command is
+vendor-independent and resolves to the shared contract in
+`integrations/shared/goal-command-contract.md`.
+
+Every adapter must:
+
+- Read the referenced goal file.
+- Check current repo state before editing.
+- Execute only that goal.
+- Run the explicit checks named by the goal.
+- Produce a PR-ready summary with objective, files changed, checks, cleanup
+  findings, and deferred work.
+- Wait for configured PR review comments and address comments relevant to the
+  goal before completion.
 
 Agent workflow (canonical)
 --------------------------
@@ -30,7 +51,7 @@ Agent workflow (canonical)
    - Run `udd status` again to confirm passing state and no orphaned journeys.
 
 Handoff protocol
------------------
+----------------
 When pausing work or passing to another agent/person, include the following in the handoff note (in PR, issue, or handoff doc):
 
 - Context: one-line summary of the user journey, actor, and goal.
@@ -72,9 +93,14 @@ Verification checklist
 
 Guidelines and constraints
 --------------------------
-- Single-task rule: agents should accept exactly one atomic task at a time (one file, one change, one verification). If multiple tasks are given, refuse and request a single-task instruction.
-- Never implement behavior not specified by a journey or feature — ask for clarification.
-- Keep changes minimal and reversible: small commits, no force pushes to protected branches.
+- Goal-file rule: when invoked through `/goal`, agents execute the referenced
+  goal file end to end and do not add unrelated cleanup.
+- Never implement behavior not specified by a journey, feature, or accepted goal
+  file.
+- Keep changes minimal and reversible: small commits, one focused PR, no force
+  pushes to protected branches.
+- Keep reusable workflow rules in `integrations/shared/`; adapter docs should
+  point there instead of duplicating the canonical process.
 
 Evidence and audit
 ------------------
@@ -86,7 +112,10 @@ Appendix: Quick commands
 - udd sync — convert journeys to feature files
 - npm test — run test suite
 - npm run check — run repository checks (lint, typecheck, test subset)
+- /goal goals/<file>.md — execute one goal through the shared agent contract
 
 Change history
 --------------
 - T16: Initial agent operations playbook (created for Task 16: Agent flow and handoff)
+- 2026-05-17: Added vendor-independent `/goal` contract and adapter/shared
+  integration routing.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,18 @@
+# Agent Integrations
+
+UDD integrations are split into shared contracts and adapter-specific wiring.
+The shared layer defines how agents read project state, execute goal files, run
+checks, and prepare PR-ready evidence. Adapter directories explain how each
+agent runtime invokes that same contract.
+
+## Layout
+
+- `shared/` - vendor-neutral goal execution, project-state, status, and
+  guardrail contracts.
+- `opencode/` - OpenCode adapter notes for existing `.opencode/` commands,
+  hooks, and `udd opencode` CLI helpers.
+- `codex/` - Codex adapter notes for `/goal goals/<file>.md` execution and PR
+  review loops.
+
+Adapter code and prompt files can live in runtime-native locations, but they
+should point back to this directory when defining reusable behavior.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,49 @@
+# Codex Adapter
+
+Codex should use the same UDD goal, status, and verification contracts as other
+agents. This directory documents the adapter path without introducing a second
+workflow.
+
+## Goal Execution
+
+Codex entrypoint:
+
+```bash
+/goal goals/<file>.md
+```
+
+The command resolves to the shared contract in
+`integrations/shared/goal-command-contract.md`:
+
+- Read exactly one goal file.
+- Check repo state with `udd status`, `udd doctor`, and `git status`.
+- Execute only the referenced goal.
+- Run explicit checks and classify failures.
+- Push one focused PR with the required evidence.
+- Wait for PR comments and address comments relevant to the goal.
+- Run an independent review before completion.
+
+## Shared Utility Path
+
+Codex adapter work should consume shared UDD state and guardrails instead of
+copying OpenCode prompts:
+
+- Project state: `src/lib/agent-integration.ts`, `src/lib/status.ts`,
+  `src/lib/query.ts`.
+- Goal contract: `integrations/shared/goal-command-contract.md`.
+- Goal template: `goals/TEMPLATE.md`.
+- Operations playbook: `docs/process/udd-agent-operations.md`.
+
+## Adapter Scope
+
+In scope for a future Codex adapter:
+
+- A concise Codex prompt or skill that points to the shared contract.
+- A wrapper that prepares the prompt-to-artifact checklist from a goal file.
+- PR comment review instructions that reuse the shared completion audit.
+
+Out of scope for this slice:
+
+- Full Codex plugin implementation.
+- Forking the OpenCode command set.
+- Runtime-specific status formats that duplicate shared payloads.

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,40 @@
+# OpenCode Adapter
+
+OpenCode is one UDD agent adapter. Its runtime-native files remain under
+`.opencode/`, while reusable workflow semantics live in `integrations/shared/`
+and shared source helpers.
+
+## Adapter Surface
+
+- `.opencode/command/udd/*.md` - OpenCode slash-command prompts.
+- `.opencode/agent/*.md` - OpenCode agent profiles.
+- `.opencode/hooks/pre-task.sh` - OpenCode guardrail hook.
+- `.opencode/plugin/udd-enforcement.ts` - OpenCode-specific enforcement plugin.
+- `src/commands/opencode.ts` - CLI adapter exposing OpenCode-oriented status,
+  next-work, and issue commands.
+- `specs/features/opencode/` - OpenCode adapter behavior scenarios.
+
+## Shared Dependencies
+
+The OpenCode adapter should call shared UDD utilities for project state and
+goal execution semantics:
+
+- `src/lib/agent-integration.ts` for agent payloads and reusable status shapes.
+- `integrations/shared/goal-command-contract.md` for `/goal <goal-file>`
+  behavior.
+- `udd status`, `udd doctor`, and `npm run check` for verification gates.
+
+OpenCode-specific prompts can mention OpenCode, but they should not describe
+OpenCode as the overall UDD architecture.
+
+## Migration Decisions
+
+- Keep `.opencode/` as the adapter home for OpenCode runtime files.
+- Keep `udd opencode ...` commands as adapter conveniences.
+- Move reusable payload shaping and goal semantics into shared source/docs
+  before adding Codex or future runtime behavior.
+- Schedule a follow-up migration to slim `.opencode/command/udd/iterate.md`
+  and `.opencode/command/udd/status.md` so they invoke the shared contract
+  instead of duplicating the generic iteration protocol.
+- Leave deeper orchestration rewrites for a later goal after the shared
+  contract is stable.

--- a/integrations/shared/README.md
+++ b/integrations/shared/README.md
@@ -1,0 +1,28 @@
+# Shared Agent Integration Contract
+
+This directory owns integration-neutral UDD behavior. Codex, OpenCode, and
+future adapters should reuse these contracts instead of forking separate
+workflow rules.
+
+## Shared Utilities
+
+- Project state: `src/lib/status.ts`, `src/lib/query.ts`, and
+  `src/lib/agent-integration.ts`.
+- Drift and guardrails: `udd status`, `udd doctor`, and adapter-specific calls
+  that surface the same data.
+- Goal execution: `/goal <goal-file>` as defined in
+  `goal-command-contract.md`.
+
+## Adapter Rules
+
+An adapter may add runtime-specific prompt files, slash commands, hooks, or UI
+helpers. It should not redefine UDD source-of-truth rules. If an adapter needs a
+new project-state field, goal-file field, or verification gate, add it to the
+shared contract first and then expose it through the adapter.
+
+## Migration Notes
+
+The first shared extraction is `src/lib/agent-integration.ts`, which builds
+vendor-neutral project snapshots, scenario totals, issue summaries, edit plans,
+and the goal-command contract. The OpenCode CLI adapter now wraps those helpers
+instead of owning the status JSON shape entirely.

--- a/integrations/shared/goal-command-contract.md
+++ b/integrations/shared/goal-command-contract.md
@@ -1,0 +1,48 @@
+# Goal Command Contract
+
+The `/goal <goal-file>` command is vendor-independent. It means: read one goal
+file, execute only that goal, verify it with explicit evidence, and prepare one
+focused PR.
+
+## Required Goal Fields
+
+Goal files must provide enough structure for any adapter to execute safely:
+
+- `Objective` - the project state that must be true when the PR lands.
+- `Explicit Checks` - yes/no completion checks that map to artifacts.
+- `Measurables` - concrete targets or counts that prove scope.
+- `Verification Commands` - commands the adapter must run or classify.
+- `PR Notes` - evidence that must appear in the PR body.
+
+`goals/TEMPLATE.md` is the canonical file template for these fields.
+
+## Execution Steps
+
+1. Read the requested goal file.
+2. Check current repo state with `udd status`, `udd doctor`, and `git status`.
+3. Build a prompt-to-artifact checklist from every explicit requirement.
+4. Execute only the referenced goal.
+5. Run narrow checks for changed implementation, then goal-required broad
+   checks.
+6. Create one focused branch and PR.
+7. Include objective, files changed, checks, cleanup findings, deferred work,
+   and verification output in the PR body.
+8. Wait for PR comments from configured reviewers.
+9. Address comments relevant to the goal and record out-of-scope findings as
+   follow-up work.
+10. Perform an independent review before declaring completion.
+
+## Completion Rules
+
+Do not mark a goal complete because checks passed by proxy. Completion requires
+evidence for every explicit field, task, measurable, named command, and PR
+deliverable in the goal file. If a command fails because of known baseline debt
+or environment limits, record the exact failure and run the narrowest relevant
+substitute checks.
+
+## Adapter Responsibilities
+
+Adapters may choose their own invocation syntax around the contract. For UDD,
+`/goal goals/<file>.md` is the stable command form. Adapter-specific command
+aliases must resolve back to this contract rather than introducing separate
+goal semantics.

--- a/product/journeys/agent-customization.md
+++ b/product/journeys/agent-customization.md
@@ -1,22 +1,23 @@
 # Journey: Agent Customization
 
 **Actor**: Developer  
-**Goal**: Customize the GitHub Copilot agent for UDD workflows
+**Goal**: Configure agent adapters to use shared UDD workflow guidance
 
 ## Context
 
-The Copilot agent needs context about UDD to assist effectively. This journey
-ensures the agent has access to project status and can guide users.
+Agent runtimes need context about UDD to assist effectively. This journey
+ensures Codex, OpenCode, and future adapters can access project status and guide
+users through the same source-of-truth workflow.
 
 ## Steps
 
-1. Developer opens Copilot chat
+1. Developer opens an agent adapter
 2. Agent has access to `udd status` output → `specs/features/udd/agent/status_prompt.feature`
 3. Agent guides user through UDD process → `specs/features/udd/agent/guide_user.feature`
 4. User gets contextual assistance
-5. Check deep status → `specs/features/opencode/tools/status_deep.feature`
-6. Get next recommendation → `specs/features/opencode/tools/next_recommendation.feature`
-7. List all issues → `specs/features/opencode/tools/issues_list.feature`
+5. OpenCode adapter checks deep status → `specs/features/opencode/tools/status_deep.feature`
+6. OpenCode adapter gets next recommendation → `specs/features/opencode/tools/next_recommendation.feature`
+7. OpenCode adapter lists all issues → `specs/features/opencode/tools/issues_list.feature`
 
 ## Success Criteria
 

--- a/product/journeys/beads-plan-workflow.md
+++ b/product/journeys/beads-plan-workflow.md
@@ -37,7 +37,7 @@ The current plan system uses a simple list of issues with basic dependency track
 
 ## Phase
 
-Phase 3 - OpenCode Integration
+Phase 3 - Agent Integration
 
 ## Notes
 

--- a/product/journeys/validate-phase-consistency.md
+++ b/product/journeys/validate-phase-consistency.md
@@ -10,7 +10,7 @@ UDD uses `specs/VISION.md` as the stable statement of project purpose and
 @phase:N tags to indicate which phase they belong to. These can drift:
 
 - VISION says agent integrations should be reusable across tools
-- `specs/roadmap.yml` says `current_phase: opencode-integration` (Phase 3)
+- `specs/roadmap.yml` says `current_phase: opencode-integration` (legacy Phase 3 id, now named Agent Integration)
 - Feature files have @phase:4 tags (Agent Intelligence phase)
 - No automated validation catches this mismatch
 

--- a/specs/features/opencode/tools/status_deep.feature
+++ b/specs/features/opencode/tools/status_deep.feature
@@ -41,10 +41,10 @@ Feature: udd opencode status (deep)
 
   @phase:3 @opencode @status
   Scenario: Status command shows current phase from specs/roadmap.yml
-    Given specs/roadmap.yml declares the current phase as "Phase 3 - OpenCode Integration"
+    Given specs/roadmap.yml declares the current phase as "Phase 3 - Agent Integration"
     When I run "udd opencode status"
     Then the command should exit with code 0
-    And the output should contain "Current Phase: Phase 3 - OpenCode Integration"
+    And the output should contain "Current Phase: Phase 3 - Agent Integration"
 
   @phase:3 @opencode @status
   Scenario: Status command identifies blocking issues

--- a/specs/features/udd/compliance/phase-consistency-validation.feature
+++ b/specs/features/udd/compliance/phase-consistency-validation.feature
@@ -46,7 +46,7 @@ Feature: Phase Consistency Validation
   @phase:3
   Scenario: Warn when roadmap and specs are misaligned
     Given specs/roadmap.yml specifies current phase 3
-    And the active phase name is "OpenCode Integration"
+    And the active phase name is "Agent Integration"
     When I scan all feature files
     Then features with @phase:4 should trigger a warning
     And the warning should explain: "Phase 4 work detected but current phase is 3"

--- a/specs/roadmap.yml
+++ b/specs/roadmap.yml
@@ -11,18 +11,18 @@ phases:
     number: 1
     status: completed
     description: "Basic scaffolding, validation, status reporting"
-    
+
   - id: research-specs
     name: "Research & Tech Specs"
     number: 2
     status: completed
     description: "Research workflow, tech spec scaffolding"
-    
+
   - id: opencode-integration
-    name: "OpenCode Integration"
+    name: "Agent Integration"
     number: 3
     status: active
-    description: "Custom tools, orchestrator plugin, JSON output"
+    description: "Shared integration contracts, adapter tools, orchestrator plugin, JSON output"
     use_cases:
       - id: orchestrated_iteration
         capability: autonomous-development
@@ -32,19 +32,19 @@ phases:
           - opencode/orchestration/stop_on_error
           - opencode/orchestration/configurable_iteration
           - opencode/tools/udd_status_tool
-          
+
       - id: agent_customization
         capability: autonomous-development
         increment: v1-basic
         scenarios:
           - opencode/agent/customize_prompts
-          
+
       - id: capture_ideas
         capability: idea-management
         increment: v1-basic
         scenarios:
           - udd/cli/inbox/add_item_via_cli
-          
+
       - id: track_test_quality
         capability: test-governance
         increment: v1-basic
@@ -52,7 +52,7 @@ phases:
           - udd/test-governance/test-linkage
           - udd/test-governance/test-status
           - udd/test-governance/test-review
-          
+
       - id: prevent_regression
         capability: test-governance
         increment: v1-basic
@@ -60,14 +60,14 @@ phases:
           - udd/test-governance/feature-change-detection
           - udd/test-governance/dirty-marking
           - udd/test-governance/sync-dirty-marking
-          
+
       - id: manage_test_lifecycle
         capability: test-governance
         increment: v1-basic
         scenarios:
           - udd/test-governance/test-scan
           - udd/test-governance/test-approval
-          
+
       - id: enforce_quality_gates
         capability: test-governance
         increment: v1-basic
@@ -75,7 +75,7 @@ phases:
           - udd/test-governance/hooks-installation
           - udd/test-governance/pre-commit-validation
           - udd/test-governance/ci-validation
-          
+
       - id: monitor_test_health
         capability: test-governance
         increment: v1-basic
@@ -83,19 +83,19 @@ phases:
           - udd/test-governance/status-integration
           - udd/test-governance/health-metrics
           - udd/test-governance/setup-health-check
-          
+
       - id: validate_phase_consistency
         capability: compliance
         increment: v1-basic
         scenarios:
           - udd/compliance/phase-consistency-validation
-          
+
   - id: agent-intelligence
     name: "Agent Intelligence"
     number: 4
     status: planned
-    description: "Copilot integration improvements, autonomous maintenance, smart suggestions"
-    
+    description: "Adapter-neutral agent intelligence, autonomous maintenance, smart suggestions"
+
   - id: advanced-workflows
     name: "Advanced Workflows"
     number: 5
@@ -116,20 +116,20 @@ capabilities:
         use_cases:
           - orchestrated_iteration
           - agent_customization
-          
+
       - version: v2-advanced
         phase: agent-intelligence
         number: 4
         status: planned
         use_cases:
           - orchestrated_iteration_advanced
-          
+
       - version: v3-full
         phase: advanced-workflows
         number: 5
         status: vision
         use_cases: []
-        
+
   idea-management:
     name: "Idea Management"
     description: "Enduring ability to capture and organize ideas"
@@ -141,7 +141,7 @@ capabilities:
         status: delivered
         use_cases:
           - capture_ideas
-          
+
   test-governance:
     name: "Test Governance"
     description: "Enduring ability to track, review, and enforce test quality"
@@ -157,13 +157,13 @@ capabilities:
           - manage_test_lifecycle
           - enforce_quality_gates
           - monitor_test_health
-          
+
       - version: v2-advanced
         phase: agent-intelligence
         number: 4
         status: planned
         use_cases: []
-        
+
   compliance:
     name: "Compliance & Validation"
     description: "Enduring ability to validate project consistency and compliance"
@@ -180,16 +180,16 @@ capabilities:
 validation_rules:
   # Scenario @phase tags must match their use case's phase
   scenario_phase_must_match_use_case_phase: true
-  
+
   # Use case phase must match roadmap phase assignment
   use_case_phase_must_match_roadmap_phase: true
-  
+
   # Allow planning features for future phases
   allow_future_phase_planning: true
-  
+
   # Strict mode fails on warnings
   strict_mode: false
-  
+
   # Maximum phase gap allowed (phases ahead of current)
   max_phase_ahead: 1
 
@@ -197,9 +197,9 @@ validation_rules:
 traceability:
   # Every scenario must have a corresponding test
   require_test_per_scenario: true
-  
+
   # Every use case must have at least one journey
   require_journey_per_use_case: true
-  
+
   # Every capability must have at least one use case
   require_use_case_per_capability: true

--- a/specs/use-cases/agent_customization.yml
+++ b/specs/use-cases/agent_customization.yml
@@ -1,9 +1,9 @@
 id: agent_customization
 name: Agent Customization
-summary: "Customize the GitHub Copilot agent for UDD"
+summary: "Configure agent adapters to reuse shared UDD workflow guidance"
 phase: 3
 actors:
-  - user
+  - developer
 outcomes:
   - description: "Agent has access to project status"
     scenarios:
@@ -11,12 +11,12 @@ outcomes:
   - description: "Agent guides user through UDD process"
     scenarios:
       - "udd/agent/guide_user"
-  - description: "Agent can check deep status"
+  - description: "OpenCode adapter can check deep status"
     scenarios:
       - "opencode/tools/status_deep"
-  - description: "Agent can get next recommendation"
+  - description: "OpenCode adapter can get next recommendation"
     scenarios:
       - "opencode/tools/next_recommendation"
-  - description: "Agent can list all issues"
+  - description: "OpenCode adapter can list all issues"
     scenarios:
       - "opencode/tools/issues_list"

--- a/specs/use-cases/orchestrated_iteration.yml
+++ b/specs/use-cases/orchestrated_iteration.yml
@@ -1,6 +1,6 @@
 id: orchestrated_iteration
 name: Orchestrated Iteration
-summary: Enable continuous autonomous development using an orchestrator agent that coordinates worker agents via the OpenCode SDK, iterating until project completion or error state.
+summary: Enable continuous autonomous development using an orchestrator agent that coordinates worker agents through a shared UDD integration contract and adapter-specific runtime.
 phase: 3
 actors:
   - developer

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -2,8 +2,38 @@ import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
+import {
+	buildAgentEditPlan,
+	buildAgentProjectSnapshot,
+	getAgentHealthLabel,
+	summarizeIssuesBySeverity,
+} from "../lib/agent-integration.js";
 import { getProjectStatus, type ProjectStatus } from "../lib/status.js";
-import { type DriftIssue, type DriftState, detectDrift } from "./doctor.js";
+import { type DriftState, detectDrift } from "./doctor.js";
+
+type SuggestedFile = { path: string; action: string };
+type JsonSuggestedFile =
+	| SuggestedFile
+	| { path: string; suggested_action: string };
+type JourneyWithBlocking = ProjectStatus["journeys"][string] & {
+	blocking?: string[];
+};
+type RecommendationJsonOutput = {
+	recommended: string;
+	reason: string;
+	suggestedFiles: JsonSuggestedFile[];
+	suggested_files: JsonSuggestedFile[];
+	edit_plan: SuggestedFile[];
+	editPlan: SuggestedFile[];
+	blocking: Array<{ slug: string; blocked_by?: string }>;
+	recommendation: string;
+	generated_at: string;
+	chosen_phase?: number;
+	scored_priorities?: Array<{ phase: number; score: number }>;
+	recommended_phase?: number;
+	recommended_meta?: { phase?: number };
+	human_summary?: string;
+};
 
 /**
  * Format a journey status for display
@@ -85,28 +115,10 @@ function formatIssuesList(drift: DriftState): string {
  * Get a health summary string
  */
 function getHealthSummary(status: ProjectStatus, drift: DriftState): string {
-	const totalJourneys = Object.keys(status.journeys).length;
-	const staleJourneys = Object.values(status.journeys).filter(
-		(j) => j.isStale,
-	).length;
-
-	let totalScenarios = 0;
-	let missingScenarios = 0;
-	let failingScenarios = 0;
-	let passingScenarios = 0;
-
-	for (const feature of Object.values(status.features)) {
-		for (const scenario of Object.values(feature.scenarios)) {
-			totalScenarios++;
-			if (scenario.e2e === "missing") missingScenarios++;
-			else if (scenario.e2e === "failing") failingScenarios++;
-			else if (scenario.e2e === "passing") passingScenarios++;
-		}
-	}
-
-	if (drift.issues.length === 0) {
+	const label = getAgentHealthLabel(status, drift);
+	if (label === "Healthy") {
 		return chalk.green("Healthy");
-	} else if (drift.summary.critical === 0) {
+	} else if (label === "Issues detected") {
 		return chalk.yellow("Issues detected");
 	} else {
 		return chalk.red("Critical issues");
@@ -117,7 +129,7 @@ function getHealthSummary(status: ProjectStatus, drift: DriftState): string {
  * Status subcommand - Deep project status for agents
  */
 export const statusCommand = new Command("status")
-	.description("Deep project status for OpenCode agents")
+	.description("Deep project status for the OpenCode adapter")
 	.option("--json", "Output status as JSON for agent consumption")
 	.action(async (options) => {
 		try {
@@ -128,80 +140,7 @@ export const statusCommand = new Command("status")
 
 			if (options.json) {
 				// Structured JSON output for agents
-				const jsonOutput = {
-					project: {
-						name: process.cwd().split("/").pop() || "unknown",
-						root: process.cwd(),
-					},
-					phase: {
-						current: status.current_phase,
-						name: status.phases[status.current_phase.toString()] || "Unknown",
-						all: status.phases,
-					},
-					journeys: Object.entries(status.journeys).map(([key, journey]) => ({
-						name: key,
-						display_name: journey.name,
-						actor: journey.actor,
-						goal: journey.goal,
-						status:
-							journey.scenariosMissing > 0
-								? "incomplete"
-								: journey.isStale
-									? "stale"
-									: "complete",
-						scenario_count: journey.scenarioCount,
-						scenarios_missing: journey.scenariosMissing,
-						scenarios_passing: journey.scenariosPassing,
-						is_stale: journey.isStale,
-					})),
-					scenarios: {
-						total: Object.values(status.features).reduce(
-							(acc, f) => acc + Object.keys(f.scenarios).length,
-							0,
-						),
-						passing: Object.values(status.features).reduce(
-							(acc, f) =>
-								acc +
-								Object.values(f.scenarios).filter((s) => s.e2e === "passing")
-									.length,
-							0,
-						),
-						failing: Object.values(status.features).reduce(
-							(acc, f) =>
-								acc +
-								Object.values(f.scenarios).filter((s) => s.e2e === "failing")
-									.length,
-							0,
-						),
-						missing: Object.values(status.features).reduce(
-							(acc, f) =>
-								acc +
-								Object.values(f.scenarios).filter((s) => s.e2e === "missing")
-									.length,
-							0,
-						),
-						stale: Object.values(status.features).reduce(
-							(acc, f) =>
-								acc +
-								Object.values(f.scenarios).filter((s) => s.e2e === "stale")
-									.length,
-							0,
-						),
-					},
-					issues: drift.issues.map((issue) => ({
-						id: issue.id,
-						severity: issue.severity,
-						type: issue.type,
-						file: issue.file,
-						message: issue.message,
-						auto_fixable: issue.autoFixable,
-					})),
-					health: {
-						status: drift.status,
-						summary: drift.summary,
-					},
-					generated_at: new Date().toISOString(),
-				};
+				const jsonOutput = buildAgentProjectSnapshot(status, drift);
 				console.log(JSON.stringify(jsonOutput, null, 2));
 			} else {
 				// Human-readable output
@@ -241,11 +180,11 @@ export const statusCommand = new Command("status")
  */
 async function findNextRecommendation(
 	status: ProjectStatus,
-	drift: DriftState,
+	_drift: DriftState,
 ): Promise<{
 	recommended: string;
 	reason: string;
-	suggestedFiles: Array<{ path: string; action: string }>;
+	suggestedFiles: SuggestedFile[];
 	blocking: Array<{ slug: string; blocked_by?: string }>;
 }> {
 	// prefer recommending direct product work (fixing a missing scenario)
@@ -259,11 +198,12 @@ async function findNextRecommendation(
 	// Aggregate blocking info across all journeys so consumers can see dependencies
 	const aggregatedBlocking: Array<{ slug: string; blocked_by: string }> = [];
 	for (const [jk, jv] of Object.entries(status.journeys)) {
+		const journeyWithBlocking = jv as JourneyWithBlocking;
 		if (
-			Array.isArray((jv as any).blocking) &&
-			(jv as any).blocking.length > 0
+			Array.isArray(journeyWithBlocking.blocking) &&
+			journeyWithBlocking.blocking.length > 0
 		) {
-			for (const b of (jv as any).blocking) {
+			for (const b of journeyWithBlocking.blocking) {
 				aggregatedBlocking.push({ slug: jk, blocked_by: b });
 			}
 		}
@@ -298,7 +238,7 @@ async function findNextRecommendation(
 			blocking:
 				aggregatedBlocking.length > 0
 					? aggregatedBlocking
-					: (journey as any).blocking?.map((b: string) => ({
+					: (journey as JourneyWithBlocking).blocking?.map((b: string) => ({
 							slug: journeyKey,
 							blocked_by: b,
 						})) || [],
@@ -392,7 +332,7 @@ async function findNextRecommendation(
 				blocking,
 			};
 		}
-	} catch (e) {
+	} catch (_e) {
 		// swallow any error - fall through to default
 	}
 
@@ -432,14 +372,9 @@ export const nextCommand = new Command("next")
 			if (options.json) {
 				// Base output: include both camelCase and snake_case variants to be
 				// tolerant with downstream agents and tests.
-				const editPlan = recommendation.suggestedFiles.map(
-					(f: { path: string; action: string }) => ({
-						path: f.path,
-						action: f.action,
-					}),
-				);
+				const editPlan = buildAgentEditPlan(recommendation.suggestedFiles);
 
-				const jsonOutput: any = {
+				const jsonOutput: RecommendationJsonOutput = {
 					// spread core fields
 					...recommendation,
 					// ensure both naming styles exist
@@ -577,15 +512,11 @@ export const issuesCommand = new Command("issues")
 				console.log(chalk.dim("==============\n"));
 
 				// Summary by severity
-				const criticalCount = drift.issues.filter(
-					(i) => i.severity === "critical",
-				).length;
-				const warningCount = drift.issues.filter(
-					(i) => i.severity === "warning",
-				).length;
-				const infoCount = drift.issues.filter(
-					(i) => i.severity === "info",
-				).length;
+				const {
+					critical: criticalCount,
+					warning: warningCount,
+					info: infoCount,
+				} = summarizeIssuesBySeverity(drift.issues);
 
 				console.log("Summary:");
 				console.log(
@@ -639,7 +570,7 @@ export const issuesCommand = new Command("issues")
  * Main opencode command with subcommands
  */
 export const opencodeCommand = new Command("opencode")
-	.description("OpenCode agent integration commands")
+	.description("OpenCode adapter integration commands")
 	.addCommand(statusCommand)
 	.addCommand(nextCommand)
 	.addCommand(issuesCommand);

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -15,9 +15,6 @@ type SuggestedFile = { path: string; action: string };
 type JsonSuggestedFile =
 	| SuggestedFile
 	| { path: string; suggested_action: string };
-type JourneyWithBlocking = ProjectStatus["journeys"][string] & {
-	blocking?: string[];
-};
 type RecommendationJsonOutput = {
 	recommended: string;
 	reason: string;
@@ -198,12 +195,8 @@ async function findNextRecommendation(
 	// Aggregate blocking info across all journeys so consumers can see dependencies
 	const aggregatedBlocking: Array<{ slug: string; blocked_by: string }> = [];
 	for (const [jk, jv] of Object.entries(status.journeys)) {
-		const journeyWithBlocking = jv as JourneyWithBlocking;
-		if (
-			Array.isArray(journeyWithBlocking.blocking) &&
-			journeyWithBlocking.blocking.length > 0
-		) {
-			for (const b of journeyWithBlocking.blocking) {
+		if (Array.isArray(jv.blocking) && jv.blocking.length > 0) {
+			for (const b of jv.blocking) {
 				aggregatedBlocking.push({ slug: jk, blocked_by: b });
 			}
 		}
@@ -238,7 +231,7 @@ async function findNextRecommendation(
 			blocking:
 				aggregatedBlocking.length > 0
 					? aggregatedBlocking
-					: (journey as JourneyWithBlocking).blocking?.map((b: string) => ({
+					: journey.blocking?.map((b: string) => ({
 							slug: journeyKey,
 							blocked_by: b,
 						})) || [],

--- a/src/commands/orchestrate.ts
+++ b/src/commands/orchestrate.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command } from "commander";
+import { describeProjectState } from "../lib/agent-integration.js";
 import { getProjectStatus } from "../lib/status.js";
 import { detectDrift } from "./doctor.js";
 
@@ -107,7 +108,7 @@ function shouldPause(
  */
 async function executeIteration(
 	iteration: number,
-	config: OrchestratorConfig,
+	_config: OrchestratorConfig,
 ): Promise<IterationState> {
 	const actions: IterationAction[] = [];
 
@@ -125,7 +126,7 @@ async function executeIteration(
 		]);
 
 		actions[0].status = "success";
-		actions[0].result = `Phase ${status.current_phase}, ${Object.keys(status.journeys).length} journeys`;
+		actions[0].result = describeProjectState(status);
 
 		// Step 2: Determine if there's work to do
 		actions.push({
@@ -305,7 +306,7 @@ function formatResult(result: OrchestrationResult): string {
 	// Metrics
 	lines.push(chalk.bold("Iterations: ") + result.iterations.toString());
 	lines.push(
-		chalk.bold("Duration: ") + `${(result.durationMs / 1000).toFixed(2)}s`,
+		`${chalk.bold("Duration: ")}${(result.durationMs / 1000).toFixed(2)}s`,
 	);
 
 	// Message
@@ -359,7 +360,7 @@ export const orchestrateCommand = new Command("orchestrate")
 		try {
 			// Parse and validate options
 			const maxIterations = parseInt(options.maxIterations, 10);
-			if (isNaN(maxIterations) || maxIterations < 1) {
+			if (Number.isNaN(maxIterations) || maxIterations < 1) {
 				throw new Error(
 					`Invalid max-iterations: ${options.maxIterations}. Must be a positive integer.`,
 				);

--- a/src/lib/agent-integration.ts
+++ b/src/lib/agent-integration.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { ProjectStatus } from "./status.js";
 
 export interface AgentDriftIssue {
@@ -75,17 +76,25 @@ export interface GoalCommandContract {
 }
 
 export function getScenarioTotals(status: ProjectStatus): ScenarioTotals {
-	const scenarios = Object.values(status.features).flatMap((feature) =>
-		Object.values(feature.scenarios),
-	);
-
-	return {
-		total: scenarios.length,
-		passing: scenarios.filter((scenario) => scenario.e2e === "passing").length,
-		failing: scenarios.filter((scenario) => scenario.e2e === "failing").length,
-		missing: scenarios.filter((scenario) => scenario.e2e === "missing").length,
-		stale: scenarios.filter((scenario) => scenario.e2e === "stale").length,
+	const totals: ScenarioTotals = {
+		total: 0,
+		passing: 0,
+		failing: 0,
+		missing: 0,
+		stale: 0,
 	};
+
+	for (const feature of Object.values(status.features)) {
+		for (const scenario of Object.values(feature.scenarios)) {
+			totals.total++;
+			if (scenario.e2e === "passing") totals.passing++;
+			else if (scenario.e2e === "failing") totals.failing++;
+			else if (scenario.e2e === "missing") totals.missing++;
+			else if (scenario.e2e === "stale") totals.stale++;
+		}
+	}
+
+	return totals;
 }
 
 export function summarizeIssuesBySeverity(issues: AgentDriftIssue[]): {
@@ -93,11 +102,11 @@ export function summarizeIssuesBySeverity(issues: AgentDriftIssue[]): {
 	warning: number;
 	info: number;
 } {
-	return {
-		critical: issues.filter((issue) => issue.severity === "critical").length,
-		warning: issues.filter((issue) => issue.severity === "warning").length,
-		info: issues.filter((issue) => issue.severity === "info").length,
-	};
+	const counts = { critical: 0, warning: 0, info: 0 };
+	for (const issue of issues) {
+		counts[issue.severity]++;
+	}
+	return counts;
 }
 
 export function buildAgentEditPlan(
@@ -130,7 +139,7 @@ export function buildAgentProjectSnapshot(
 ): AgentProjectSnapshot {
 	return {
 		project: {
-			name: root.split("/").pop() || "unknown",
+			name: path.basename(root) || "unknown",
 			root,
 		},
 		phase: {

--- a/src/lib/agent-integration.ts
+++ b/src/lib/agent-integration.ts
@@ -1,0 +1,204 @@
+import type { ProjectStatus } from "./status.js";
+
+export interface AgentDriftIssue {
+	id: string;
+	severity: "critical" | "warning" | "info";
+	type: string;
+	file: string;
+	message: string;
+	autoFixable: boolean;
+	requiresUserInput?: boolean;
+}
+
+export interface AgentDriftState {
+	status: "clean" | "drift-detected";
+	lastCheck?: string;
+	summary: {
+		critical: number;
+		warning: number;
+		info: number;
+		total: number;
+	};
+	issues: AgentDriftIssue[];
+}
+
+export interface AgentProjectSnapshot {
+	project: {
+		name: string;
+		root: string;
+	};
+	phase: {
+		current: number;
+		name: string;
+		all: Record<string, string>;
+	};
+	journeys: Array<{
+		name: string;
+		display_name: string;
+		actor: string;
+		goal: string;
+		status: "incomplete" | "stale" | "complete";
+		scenario_count: number;
+		scenarios_missing: number;
+		scenarios_passing: number;
+		is_stale: boolean;
+	}>;
+	scenarios: ScenarioTotals;
+	issues: Array<{
+		id: string;
+		severity: AgentDriftIssue["severity"];
+		type: AgentDriftIssue["type"];
+		file: string;
+		message: string;
+		auto_fixable: boolean;
+	}>;
+	health: {
+		status: AgentDriftState["status"];
+		summary: AgentDriftState["summary"];
+	};
+	generated_at: string;
+}
+
+export interface ScenarioTotals {
+	total: number;
+	passing: number;
+	failing: number;
+	missing: number;
+	stale: number;
+}
+
+export interface GoalCommandContract {
+	command: "/goal <goal-file>";
+	requiredFields: string[];
+	executionSteps: string[];
+	prSummaryFields: string[];
+}
+
+export function getScenarioTotals(status: ProjectStatus): ScenarioTotals {
+	const scenarios = Object.values(status.features).flatMap((feature) =>
+		Object.values(feature.scenarios),
+	);
+
+	return {
+		total: scenarios.length,
+		passing: scenarios.filter((scenario) => scenario.e2e === "passing").length,
+		failing: scenarios.filter((scenario) => scenario.e2e === "failing").length,
+		missing: scenarios.filter((scenario) => scenario.e2e === "missing").length,
+		stale: scenarios.filter((scenario) => scenario.e2e === "stale").length,
+	};
+}
+
+export function summarizeIssuesBySeverity(issues: AgentDriftIssue[]): {
+	critical: number;
+	warning: number;
+	info: number;
+} {
+	return {
+		critical: issues.filter((issue) => issue.severity === "critical").length,
+		warning: issues.filter((issue) => issue.severity === "warning").length,
+		info: issues.filter((issue) => issue.severity === "info").length,
+	};
+}
+
+export function buildAgentEditPlan(
+	suggestedFiles: Array<{ path: string; action: string }>,
+): Array<{ path: string; action: string }> {
+	return suggestedFiles.map((file) => ({
+		path: file.path,
+		action: file.action,
+	}));
+}
+
+export function getAgentHealthLabel(
+	_status: ProjectStatus,
+	drift: AgentDriftState,
+): "Healthy" | "Issues detected" | "Critical issues" {
+	if (drift.issues.length === 0) return "Healthy";
+	if (drift.summary.critical === 0) return "Issues detected";
+	return "Critical issues";
+}
+
+export function describeProjectState(status: ProjectStatus): string {
+	return `Phase ${status.current_phase}, ${Object.keys(status.journeys).length} journeys`;
+}
+
+export function buildAgentProjectSnapshot(
+	status: ProjectStatus,
+	drift: AgentDriftState,
+	root = process.cwd(),
+	now = new Date(),
+): AgentProjectSnapshot {
+	return {
+		project: {
+			name: root.split("/").pop() || "unknown",
+			root,
+		},
+		phase: {
+			current: status.current_phase,
+			name: status.phases[status.current_phase.toString()] || "Unknown",
+			all: status.phases,
+		},
+		journeys: Object.entries(status.journeys).map(([key, journey]) => ({
+			name: key,
+			display_name: journey.name,
+			actor: journey.actor,
+			goal: journey.goal,
+			status:
+				journey.scenariosMissing > 0
+					? "incomplete"
+					: journey.isStale
+						? "stale"
+						: "complete",
+			scenario_count: journey.scenarioCount,
+			scenarios_missing: journey.scenariosMissing,
+			scenarios_passing: journey.scenariosPassing,
+			is_stale: journey.isStale,
+		})),
+		scenarios: getScenarioTotals(status),
+		issues: drift.issues.map((issue) => ({
+			id: issue.id,
+			severity: issue.severity,
+			type: issue.type,
+			file: issue.file,
+			message: issue.message,
+			auto_fixable: issue.autoFixable,
+		})),
+		health: {
+			status: drift.status,
+			summary: drift.summary,
+		},
+		generated_at: now.toISOString(),
+	};
+}
+
+export function getGoalCommandContract(): GoalCommandContract {
+	return {
+		command: "/goal <goal-file>",
+		requiredFields: [
+			"objective",
+			"explicit checks",
+			"measurables",
+			"verification commands",
+			"PR notes",
+		],
+		executionSteps: [
+			"read goal file",
+			"check current repo state",
+			"build prompt-to-artifact checklist",
+			"execute only that goal",
+			"run explicit checks",
+			"create one focused branch and PR",
+			"produce PR-ready evidence summary",
+			"wait for PR comments",
+			"address comments relevant to the goal",
+			"perform independent review",
+		],
+		prSummaryFields: [
+			"objective",
+			"files changed",
+			"checks run and results",
+			"cleanup findings",
+			"deferred work",
+		],
+	};
+}

--- a/tests/e2e/opencode/tools/status_deep.e2e.test.ts
+++ b/tests/e2e/opencode/tools/status_deep.e2e.test.ts
@@ -138,7 +138,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
 			let runResult: { stdout: string; stderr: string };
 
 			Given(
-				'specs/roadmap.yml declares the current phase as "Phase 3 - OpenCode Integration"',
+				'specs/roadmap.yml declares the current phase as "Phase 3 - Agent Integration"',
 				async () => {
 					const tempDir = await mkdtemp(path.join(os.tmpdir(), "udd-test-"));
 					await runUdd("init --yes", { cwd: tempDir });
@@ -150,7 +150,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
 							"phases:",
 							"  - id: opencode-integration",
 							"    number: 3",
-							'    name: "OpenCode Integration"',
+							'    name: "Agent Integration"',
 							"",
 						].join("\n"),
 					);
@@ -167,10 +167,10 @@ describeFeature(feature, ({ Background, Scenario }) => {
 			});
 
 			And(
-				'the output should contain "Current Phase: Phase 3 - OpenCode Integration"',
+				'the output should contain "Current Phase: Phase 3 - Agent Integration"',
 				async () => {
 					expect(statusOutput).toContain(
-						"Current Phase: Phase 3 - OpenCode Integration",
+						"Current Phase: Phase 3 - Agent Integration",
 					);
 				},
 			);
@@ -335,12 +335,12 @@ describeFeature(feature, ({ Background, Scenario }) => {
 							"phases:",
 							"  - id: opencode-integration",
 							"    number: 3",
-							'    name: "OpenCode Integration"',
+							'    name: "Agent Integration"',
 							"",
 						].join("\n"),
 					);
 					const json = JSON.parse(statusOutput);
-					expect(json.phase).toBe("Phase 3 - OpenCode Integration");
+					expect(json.phase).toBe("Phase 3 - Agent Integration");
 				},
 			);
 

--- a/tests/e2e/udd/compliance/phase_consistency_validation.e2e.test.ts
+++ b/tests/e2e/udd/compliance/phase_consistency_validation.e2e.test.ts
@@ -62,7 +62,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
 				// Stub: Set current phase
 			});
 
-			And('the active phase name is "OpenCode Integration"', () => {
+			And('the active phase name is "Agent Integration"', () => {
 				// Stub: Set phase name
 			});
 

--- a/tests/lib/agent-integration.test.ts
+++ b/tests/lib/agent-integration.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "vitest";
+import {
+	type AgentDriftState,
+	buildAgentEditPlan,
+	buildAgentProjectSnapshot,
+	getAgentHealthLabel,
+	getGoalCommandContract,
+} from "../../src/lib/agent-integration.js";
+import type { ProjectStatus } from "../../src/lib/status.js";
+
+const status: ProjectStatus = {
+	git: {
+		branch: "codex/example",
+		clean: true,
+		modified: 0,
+		staged: 0,
+		untracked: 0,
+	},
+	current_phase: 3,
+	phases: {
+		"3": "Agent Integration",
+	},
+	active_features: ["opencode/tools"],
+	features: {
+		"opencode/tools": {
+			scenarios: {
+				status_deep: {
+					e2e: "passing",
+					isDeferred: false,
+				},
+				next_recommendation: {
+					e2e: "missing",
+					isDeferred: false,
+				},
+			},
+			requirements: {},
+		},
+	},
+	use_cases: {},
+	orphaned_scenarios: [],
+	journeys: {
+		"agent-customization": {
+			name: "Agent Customization",
+			actor: "Developer",
+			goal: "Use shared UDD integration utilities",
+			scenarioCount: 2,
+			scenariosMissing: 0,
+			scenariosPassing: 2,
+			scenariosFailing: 0,
+			hash: "abc123",
+			isStale: false,
+		},
+	},
+	hasProductDir: true,
+};
+
+const drift: AgentDriftState = {
+	status: "clean",
+	lastCheck: "2026-05-17T00:00:00.000Z",
+	summary: {
+		critical: 0,
+		warning: 0,
+		info: 0,
+		total: 0,
+	},
+	issues: [],
+};
+
+test("builds a vendor-neutral agent project snapshot", () => {
+	const snapshot = buildAgentProjectSnapshot(
+		status,
+		drift,
+		"/workspace/udd",
+		new Date("2026-05-17T00:00:00.000Z"),
+	);
+
+	expect(snapshot.project.name).toBe("udd");
+	expect(snapshot.phase.name).toBe("Agent Integration");
+	expect(snapshot.journeys[0]).toMatchObject({
+		name: "agent-customization",
+		status: "complete",
+		scenario_count: 2,
+	});
+	expect(snapshot.scenarios).toMatchObject({
+		total: 2,
+		passing: 1,
+		missing: 1,
+	});
+	expect(snapshot.generated_at).toBe("2026-05-17T00:00:00.000Z");
+});
+
+test("reports agent health from drift state", () => {
+	expect(getAgentHealthLabel(status, drift)).toBe("Healthy");
+
+	expect(
+		getAgentHealthLabel(status, {
+			...drift,
+			status: "drift-detected",
+			summary: {
+				critical: 1,
+				warning: 0,
+				info: 0,
+				total: 1,
+			},
+			issues: [
+				{
+					id: "issue-1",
+					severity: "critical",
+					type: "manifest_missing",
+					file: "specs/.udd/manifest.yml",
+					message: "Manifest missing",
+					autoFixable: true,
+					requiresUserInput: false,
+				},
+			],
+		}),
+	).toBe("Critical issues");
+});
+
+test("keeps goal command contract integration neutral", () => {
+	expect(getGoalCommandContract()).toMatchObject({
+		command: "/goal <goal-file>",
+		requiredFields: [
+			"objective",
+			"explicit checks",
+			"measurables",
+			"verification commands",
+			"PR notes",
+		],
+		executionSteps: [
+			"read goal file",
+			"check current repo state",
+			"build prompt-to-artifact checklist",
+			"execute only that goal",
+			"run explicit checks",
+			"create one focused branch and PR",
+			"produce PR-ready evidence summary",
+			"wait for PR comments",
+			"address comments relevant to the goal",
+			"perform independent review",
+		],
+	});
+
+	expect(
+		buildAgentEditPlan([{ path: "goals/example.md", action: "read" }]),
+	).toEqual([{ path: "goals/example.md", action: "read" }]);
+});


### PR DESCRIPTION
## Objective

Create a reusable agent-integration structure so Codex, OpenCode, and future agents can share UDD project-state, goal execution, status, and guardrail utilities without duplicating integration-specific logic.

## Shared Integration Layout

- Added `integrations/shared/` with the vendor-independent `/goal <goal-file>` contract and shared agent integration guidance.
- Added `integrations/opencode/` to represent OpenCode as an adapter around `.opencode/`, `udd opencode ...`, and adapter-specific specs.
- Added `integrations/codex/` to document Codex using the same goal/status/check contracts without forking OpenCode behavior.
- Added `src/lib/agent-integration.ts` for shared project snapshots, scenario totals, issue summaries, edit plans, and the source-level goal-command contract.

## Codex Integration Path

Codex uses `/goal goals/<file>.md`, then follows the shared contract: read one goal file, check repo state, build a prompt-to-artifact checklist, execute only that goal, run explicit checks, create one focused PR, wait for PR comments, address relevant comments, and perform independent review before completion.

## OpenCode Migration Decisions

- OpenCode stays supported as an adapter through `.opencode/`, `src/commands/opencode.ts`, and `specs/features/opencode/`.
- Reusable status payload shaping moved into `src/lib/agent-integration.ts`; `udd opencode` now wraps the shared helpers.
- Follow-up migration is explicitly scheduled in `integrations/opencode/README.md` to slim `.opencode/command/udd/iterate.md` and `.opencode/command/udd/status.md` so those prompts invoke the shared contract instead of duplicating generic iteration guidance.

## Goal Command Contract

The shared `/goal <goal-file>` contract now defines required goal fields: objective, explicit checks, measurables, verification commands, and PR notes. The source contract and unit test mirror the shared docs, including PR creation, PR comment handling, and independent review.

## Review Findings

Independent review found two blocking issues: Phase 4 was accidentally made Codex-specific, and the source goal contract was weaker than the doc contract. Both were fixed. It also flagged OpenCode prompt duplication as migration debt, now recorded in the OpenCode adapter README. The OpenCode status E2E JSON-shape mismatch is pre-existing: `HEAD` already emitted object-shaped `phase` and no `coverage`; this branch only updates the phase label text.

## PR Review Comment Follow-Up

Gemini review comments were addressed in `4c5375b`:

- Added `node:path` and replaced `root.split("/").pop()` with `path.basename(root)` for cross-platform project-name handling.
- Reworked `getScenarioTotals()` and `summarizeIssuesBySeverity()` to single-pass implementations.
- Removed the redundant `JourneyWithBlocking` type and casts from `src/commands/opencode.ts`.

A second independent review of the comment-fix diff found no remaining blocker before push.

## Verification

Passed:

- `npx biome check src/lib/agent-integration.ts src/commands/opencode.ts src/commands/orchestrate.ts tests/lib/agent-integration.test.ts`
- `npm test -- tests/lib/agent-integration.test.ts`
- `npm test -- tests/e2e/udd/compliance/phase_consistency_validation.e2e.test.ts`
- `git diff --check`
- `./bin/udd status` (runs with TSX IPC escalation in this environment)

Expected baseline failures / warnings:

- `./bin/udd doctor` exits 1 with 14 existing stub-assertion warnings and 0 critical issues.
- `npm run check` still fails on existing repo-wide Biome debt outside this slice, including `src/commands/hooks.ts`, `src/commands/status.ts`, `src/commands/test.ts`, `bin/udd.ts`, and existing tests.
- `tsc --noEmit` still fails on existing unrelated E2E test type errors, including `tests/e2e/opencode/tools/status_deep.e2e.test.ts` and `tests/e2e/udd/recovery/*`.
- `vitest related --run` from the pre-commit hook previously failed on existing `tests/e2e/opencode/tools/status_deep.e2e.test.ts` expectations around fixture isolation, coverage output, and legacy JSON shape; scoped new utility tests pass.