### PR TITLE
Install Codex UDD hooks

### DIFF
--- a/bin/udd.ts
+++ b/bin/udd.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { discoverCommand } from "../src/commands/discover.js";
+import { hooksCommand } from "../src/commands/hooks.js";
 import { inboxCommand } from "../src/commands/inbox.js";
 import { initCommand } from "../src/commands/init.js";
 import { lintCommand } from "../src/commands/lint.js";
@@ -25,5 +26,6 @@ program.addCommand(validateCommand);
 program.addCommand(testCommand);
 program.addCommand(inboxCommand);
 program.addCommand(queryCommand);
+program.addCommand(hooksCommand);
 
 program.parse(process.argv);

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,54 @@
+# Codex Tooling
+
+Codex should use the same UDD status, verification, and review contracts as
+other agents. This directory documents Codex-side hooks and tooling for
+UDD-driven development sessions.
+
+## Session Hook
+
+Install the Codex hook into an external UDD project:
+
+```bash
+udd hooks install-codex
+```
+
+New projects can opt in during initialization:
+
+```bash
+udd init --codex-hooks
+```
+
+Installed files:
+
+- `.codex/hooks.json`
+- `.codex/hooks/pre-task.sh`
+
+The hook is advisory and does not block work. It surfaces the same baseline
+health checks available in UDD projects:
+
+- `udd status`
+- `udd status --doctor`
+- `git status --short`
+
+## Shared Utility Path
+
+Codex tooling should consume UDD state and guardrails instead of copying
+runtime-specific prompts:
+
+- Project state: `udd status`
+- Diagnostics: `udd status --doctor`
+- Spec validation: `udd lint` and `udd validate`
+
+## Tooling Scope
+
+In scope for Codex tooling:
+
+- Lightweight hooks that report UDD project health.
+- Project initialization options that install those hooks.
+
+Out of scope for this slice:
+
+- Full Codex plugin implementation.
+- Forking the OpenCode command set.
+- Prompt or skill helpers beyond the installed hook.
+- Runtime-specific status formats that duplicate shared payloads.

--- a/specs/features/udd/cli/codex_hooks.feature
+++ b/specs/features/udd/cli/codex_hooks.feature
@@ -1,0 +1,13 @@
+Feature: UDD CLI
+
+  Scenario: Install Codex hooks into an external project
+    Given I am in a project without Codex hooks
+    When I run "udd hooks install-codex"
+    Then ".codex/hooks.json" should include the UDD Codex hook
+    And ".codex/hooks/pre-task.sh" should run UDD status checks
+
+  Scenario: Initialize a project with Codex hooks
+    Given I am in an empty project
+    When I run "udd init --yes --codex-hooks"
+    Then the UDD product structure should be created
+    And ".codex/hooks.json" should include the UDD Codex hook

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -1,0 +1,30 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { installCodexHooks } from "../lib/codex-hooks.js";
+
+export const hooksCommand = new Command("hooks").description(
+	"Manage UDD agent hooks",
+);
+
+hooksCommand
+	.command("install-codex")
+	.description("Install Codex UDD session hooks into this project")
+	.option("-f, --force", "overwrite existing Codex hook files")
+	.action(async (options: { force?: boolean }) => {
+		try {
+			const result = await installCodexHooks(process.cwd(), {
+				force: options.force,
+			});
+
+			console.log(chalk.green("✓ Codex UDD hooks installed"));
+			for (const file of result.written) {
+				console.log(chalk.dim(`  Wrote: ${file}`));
+			}
+			for (const file of result.unchanged) {
+				console.log(chalk.dim(`  Unchanged: ${file}`));
+			}
+		} catch (error) {
+			console.error(chalk.red("Error installing Codex hooks:"), error);
+			process.exit(1);
+		}
+	});

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -9,7 +9,7 @@ export const hooksCommand = new Command("hooks").description(
 hooksCommand
 	.command("install-codex")
 	.description("Install Codex UDD session hooks into this project")
-	.option("-f, --force", "overwrite existing Codex hook files")
+	.option("-f, --force", "replace conflicting Codex hook files")
 	.action(async (options: { force?: boolean }) => {
 		try {
 			const result = await installCodexHooks(process.cwd(), {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,10 +4,12 @@ import { confirm, input } from "@inquirer/prompts";
 import chalk from "chalk";
 import { Command } from "commander";
 import { userWarn } from "../lib/cli-error.js";
+import { installCodexHooks } from "../lib/codex-hooks.js";
 
 export const initCommand = new Command("init")
 	.description("Initialize UDD in a project")
 	.option("-y, --yes", "Skip prompts and use defaults")
+	.option("--codex-hooks", "Install Codex UDD session hooks")
 	.action(async (options) => {
 		const rootDir = process.cwd();
 		const productDir = path.join(rootDir, "product");
@@ -222,6 +224,11 @@ scenarios: {}
 			manifestContent,
 		);
 		console.log(chalk.green("✓ Created specs/.udd/manifest.yml"));
+
+		if (options.codexHooks) {
+			await installCodexHooks(rootDir);
+			console.log(chalk.green("✓ Installed Codex UDD hooks"));
+		}
 
 		console.log(
 			chalk.cyan(

--- a/src/lib/codex-hooks.ts
+++ b/src/lib/codex-hooks.ts
@@ -11,21 +11,22 @@ const CODEX_HOOK_GROUP = {
 		},
 	],
 };
-
 type CodexHooksConfig = {
 	hooks?: Record<string, unknown>;
 	[key: string]: unknown;
 };
 
+function createDefaultHooksConfig(): CodexHooksConfig {
+	return {
+		hooks: {
+			UserPromptSubmit: [CODEX_HOOK_GROUP],
+		},
+	};
+}
+
 function formatHooksConfig(config: CodexHooksConfig): string {
 	return `${JSON.stringify(config, null, "\t")}\n`;
 }
-
-export const CODEX_HOOKS_JSON = formatHooksConfig({
-	hooks: {
-		UserPromptSubmit: [CODEX_HOOK_GROUP],
-	},
-});
 
 export const CODEX_PRE_TASK_HOOK = `#!/usr/bin/env bash
 # Pre-task health check for Codex sessions (non-blocking).
@@ -34,9 +35,7 @@ set -euo pipefail
 echo "Codex Pre-Task Health Check"
 
 run_udd() {
-\tif [ -f "bin/udd.ts" ] && [ -d "node_modules/tsx" ]; then
-\t\tnode --import tsx bin/udd.ts "$@"
-\telif [ -x "node_modules/.bin/udd" ]; then
+\tif [ -x "node_modules/.bin/udd" ]; then
 \t\tnode_modules/.bin/udd "$@"
 \telif command -v udd >/dev/null 2>&1; then
 \t\tudd "$@"
@@ -139,16 +138,32 @@ async function writeHooksJson(
 			config = {};
 		}
 
-		config.hooks =
+		if (
 			config.hooks &&
-			typeof config.hooks === "object" &&
-			!Array.isArray(config.hooks)
-				? config.hooks
-				: {};
+			(typeof config.hooks !== "object" || Array.isArray(config.hooks))
+		) {
+			if (!options.force) {
+				throw new Error(
+					`${path.relative(process.cwd(), filePath)} has an unsupported hooks field. Re-run with --force to replace it.`,
+				);
+			}
+			config.hooks = {};
+		} else {
+			config.hooks = config.hooks ?? {};
+		}
 
-		const promptHooks = Array.isArray(config.hooks.UserPromptSubmit)
-			? config.hooks.UserPromptSubmit
-			: [];
+		let promptHooks: unknown[] = [];
+		if (config.hooks.UserPromptSubmit !== undefined) {
+			if (!Array.isArray(config.hooks.UserPromptSubmit)) {
+				if (!options.force) {
+					throw new Error(
+						`${path.relative(process.cwd(), filePath)} has an unsupported UserPromptSubmit hook list. Re-run with --force to replace it.`,
+					);
+				}
+			} else {
+				promptHooks = config.hooks.UserPromptSubmit;
+			}
+		}
 
 		if (promptHooks.some(hasCodexHook)) {
 			return "unchanged";
@@ -159,7 +174,7 @@ async function writeHooksJson(
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 			throw error;
 		}
-		config = JSON.parse(CODEX_HOOKS_JSON) as CodexHooksConfig;
+		config = createDefaultHooksConfig();
 	}
 
 	await fs.writeFile(filePath, formatHooksConfig(config));

--- a/src/lib/codex-hooks.ts
+++ b/src/lib/codex-hooks.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const CODEX_HOOK_COMMAND = ".codex/hooks/pre-task.sh";
+const CODEX_HOOK_GROUP = {
+	hooks: [
+		{
+			type: "command",
+			command: CODEX_HOOK_COMMAND,
+			timeout: 10,
+		},
+	],
+};
+
+type CodexHooksConfig = {
+	hooks?: Record<string, unknown>;
+	[key: string]: unknown;
+};
+
+function formatHooksConfig(config: CodexHooksConfig): string {
+	return `${JSON.stringify(config, null, "\t")}\n`;
+}
+
+export const CODEX_HOOKS_JSON = formatHooksConfig({
+	hooks: {
+		UserPromptSubmit: [CODEX_HOOK_GROUP],
+	},
+});
+
+export const CODEX_PRE_TASK_HOOK = `#!/usr/bin/env bash
+# Pre-task health check for Codex sessions (non-blocking).
+set -euo pipefail
+
+echo "Codex Pre-Task Health Check"
+
+run_udd() {
+\tif [ -f "bin/udd.ts" ] && [ -d "node_modules/tsx" ]; then
+\t\tnode --import tsx bin/udd.ts "$@"
+\telif [ -x "node_modules/.bin/udd" ]; then
+\t\tnode_modules/.bin/udd "$@"
+\telif command -v udd >/dev/null 2>&1; then
+\t\tudd "$@"
+\telse
+\t\treturn 127
+\tfi
+}
+
+if run_udd --help >/dev/null 2>&1; then
+\tprintf "\\n--- udd status ---\\n"
+\trun_udd status || true
+
+\tprintf "\\n--- udd status --doctor ---\\n"
+\trun_udd status --doctor || true
+else
+\techo "udd CLI not found; skipping udd status checks"
+fi
+
+printf "\\n--- git status --short ---\\n"
+git status --short || true
+
+printf "\\nPre-task health check complete. This hook is advisory only and will not block the task.\\n"
+exit 0
+`;
+
+export interface InstallCodexHooksOptions {
+	force?: boolean;
+}
+
+export interface InstallCodexHooksResult {
+	written: string[];
+	unchanged: string[];
+}
+
+async function writeManagedFile(
+	filePath: string,
+	content: string,
+	options: InstallCodexHooksOptions,
+): Promise<"written" | "unchanged"> {
+	try {
+		const existing = await fs.readFile(filePath, "utf8");
+		if (existing === content) return "unchanged";
+		if (!options.force) {
+			throw new Error(
+				`${path.relative(process.cwd(), filePath)} already exists with different content. Re-run with --force to overwrite.`,
+			);
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+
+	await fs.writeFile(filePath, content);
+	return "written";
+}
+
+function hasCodexHook(group: unknown): boolean {
+	if (!group || typeof group !== "object" || !("hooks" in group)) {
+		return false;
+	}
+
+	const hooks = (group as { hooks?: unknown }).hooks;
+	if (!Array.isArray(hooks)) return false;
+
+	return hooks.some((hook) => {
+		return (
+			hook !== null &&
+			typeof hook === "object" &&
+			(hook as { command?: unknown }).command === CODEX_HOOK_COMMAND
+		);
+	});
+}
+
+async function writeHooksJson(
+	filePath: string,
+	options: InstallCodexHooksOptions,
+): Promise<"written" | "unchanged"> {
+	let config: CodexHooksConfig;
+
+	try {
+		const existing = await fs.readFile(filePath, "utf8");
+		try {
+			config = JSON.parse(existing) as CodexHooksConfig;
+		} catch (_error) {
+			if (!options.force) {
+				throw new Error(
+					`${path.relative(process.cwd(), filePath)} is not valid JSON. Re-run with --force to replace it.`,
+				);
+			}
+			config = {};
+		}
+
+		if (!config || typeof config !== "object" || Array.isArray(config)) {
+			if (!options.force) {
+				throw new Error(
+					`${path.relative(process.cwd(), filePath)} must contain a JSON object. Re-run with --force to replace it.`,
+				);
+			}
+			config = {};
+		}
+
+		config.hooks =
+			config.hooks &&
+			typeof config.hooks === "object" &&
+			!Array.isArray(config.hooks)
+				? config.hooks
+				: {};
+
+		const promptHooks = Array.isArray(config.hooks.UserPromptSubmit)
+			? config.hooks.UserPromptSubmit
+			: [];
+
+		if (promptHooks.some(hasCodexHook)) {
+			return "unchanged";
+		}
+
+		config.hooks.UserPromptSubmit = [...promptHooks, CODEX_HOOK_GROUP];
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+		config = JSON.parse(CODEX_HOOKS_JSON) as CodexHooksConfig;
+	}
+
+	await fs.writeFile(filePath, formatHooksConfig(config));
+	return "written";
+}
+
+export async function installCodexHooks(
+	rootDir = process.cwd(),
+	options: InstallCodexHooksOptions = {},
+): Promise<InstallCodexHooksResult> {
+	const codexDir = path.join(rootDir, ".codex");
+	const hooksDir = path.join(codexDir, "hooks");
+	const hooksJsonPath = path.join(codexDir, "hooks.json");
+	const preTaskPath = path.join(hooksDir, "pre-task.sh");
+	const result: InstallCodexHooksResult = { written: [], unchanged: [] };
+
+	await fs.mkdir(hooksDir, { recursive: true });
+
+	const hooksJsonStatus = await writeHooksJson(hooksJsonPath, options);
+	result[hooksJsonStatus].push(path.relative(rootDir, hooksJsonPath));
+
+	const preTaskStatus = await writeManagedFile(
+		preTaskPath,
+		CODEX_PRE_TASK_HOOK,
+		options,
+	);
+	result[preTaskStatus].push(path.relative(rootDir, preTaskPath));
+
+	await fs.chmod(preTaskPath, 0o755);
+
+	return result;
+}

--- a/tests/e2e/udd/cli/codex_hooks.e2e.test.ts
+++ b/tests/e2e/udd/cli/codex_hooks.e2e.test.ts
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { rootDir, withTempDir } from "../../../utils.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runUddInCwd(args: string[]) {
+	const uddBin = path.resolve(rootDir, "bin/udd.ts");
+	const tsxLoader = path.resolve(rootDir, "node_modules/tsx/dist/loader.mjs");
+	return execFileAsync(process.execPath, [
+		"--import",
+		tsxLoader,
+		uddBin,
+		...args,
+	]);
+}
+
+async function readInstalledHookConfig(root: string) {
+	return JSON.parse(
+		await fs.readFile(path.join(root, ".codex/hooks.json"), "utf8"),
+	);
+}
+
+describe("codex hooks CLI", () => {
+	it("installs codex hooks into an external project", async () => {
+		await withTempDir(async () => {
+			await runUddInCwd(["hooks", "install-codex"]);
+
+			const config = await readInstalledHookConfig(process.cwd());
+			const hook = await fs.readFile(".codex/hooks/pre-task.sh", "utf8");
+
+			expect(config.hooks.UserPromptSubmit[0].hooks[0]).toMatchObject({
+				type: "command",
+				command: ".codex/hooks/pre-task.sh",
+			});
+			expect(hook).toContain("udd status");
+			expect(hook).toContain("udd status --doctor");
+		});
+	});
+
+	it("initializes a project with codex hooks", async () => {
+		await withTempDir(async () => {
+			await runUddInCwd(["init", "--yes", "--codex-hooks"]);
+
+			const config = await readInstalledHookConfig(process.cwd());
+			const productReadme = await fs.readFile("product/README.md", "utf8");
+
+			expect(productReadme).toContain("# My Product");
+			expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+				".codex/hooks/pre-task.sh",
+			);
+		});
+	});
+});

--- a/tests/lib/codex-tooling.test.ts
+++ b/tests/lib/codex-tooling.test.ts
@@ -1,0 +1,169 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { expect, test } from "vitest";
+import { installCodexHooks } from "../../src/lib/codex-hooks.js";
+
+const execFileAsync = promisify(execFile);
+
+async function withExternalProject<T>(fn: (rootDir: string) => Promise<T>) {
+	const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "udd-codex-hooks-"));
+	try {
+		return await fn(rootDir);
+	} finally {
+		await fs.rm(rootDir, { recursive: true, force: true });
+	}
+}
+
+test("installs codex hook config into an external project", async () => {
+	await withExternalProject(async (rootDir) => {
+		const result = await installCodexHooks(rootDir);
+
+		expect(result.written).toEqual([
+			".codex/hooks.json",
+			".codex/hooks/pre-task.sh",
+		]);
+
+		const config = JSON.parse(
+			await fs.readFile(path.join(rootDir, ".codex/hooks.json"), "utf8"),
+		);
+
+		expect(config.hooks.UserPromptSubmit[0].hooks[0]).toMatchObject({
+			type: "command",
+			command: ".codex/hooks/pre-task.sh",
+			timeout: 10,
+		});
+	});
+});
+
+test("codex hook installer is idempotent", async () => {
+	await withExternalProject(async (rootDir) => {
+		await installCodexHooks(rootDir);
+		const result = await installCodexHooks(rootDir);
+
+		expect(result.unchanged).toEqual([
+			".codex/hooks.json",
+			".codex/hooks/pre-task.sh",
+		]);
+	});
+});
+
+test("codex pre-task hook surfaces UDD health checks", async () => {
+	await withExternalProject(async (rootDir) => {
+		await installCodexHooks(rootDir);
+		const hook = await fs.readFile(
+			path.join(rootDir, ".codex/hooks/pre-task.sh"),
+			"utf8",
+		);
+
+		expect(hook).toContain("node --import tsx bin/udd.ts");
+		expect(hook).toContain("node_modules/.bin/udd");
+		expect(hook).toContain("udd status");
+		expect(hook).toContain("udd status --doctor");
+		expect(hook).toContain("git status --short");
+		expect(hook).not.toContain("/goal");
+		expect(hook).not.toContain("goals/");
+	});
+});
+
+test("codex pre-task hook runs project-local udd binaries", async () => {
+	await withExternalProject(async (rootDir) => {
+		await installCodexHooks(rootDir);
+		const localBin = path.join(rootDir, "node_modules/.bin");
+		await fs.mkdir(localBin, { recursive: true });
+		const localUdd = path.join(localBin, "udd");
+		await fs.writeFile(localUdd, '#!/usr/bin/env sh\necho "local udd $*"\n');
+		await fs.chmod(localUdd, 0o755);
+
+		const result = await execFileAsync("bash", [".codex/hooks/pre-task.sh"], {
+			cwd: rootDir,
+		});
+
+		expect(result.stdout).toContain("local udd status");
+		expect(result.stdout).toContain("local udd status --doctor");
+	});
+});
+
+test("codex pre-task hook runs as an advisory check", async () => {
+	await withExternalProject(async (rootDir) => {
+		await installCodexHooks(rootDir);
+		const fakeBin = path.join(rootDir, "bin");
+		await fs.mkdir(fakeBin, { recursive: true });
+		const fakeUdd = path.join(fakeBin, "udd");
+		await fs.writeFile(fakeUdd, '#!/usr/bin/env sh\necho "udd $*"\n');
+		await fs.chmod(fakeUdd, 0o755);
+
+		const result = await execFileAsync("bash", [".codex/hooks/pre-task.sh"], {
+			cwd: rootDir,
+			env: {
+				...process.env,
+				PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+			},
+		});
+
+		expect(result.stdout).toContain("Codex Pre-Task Health Check");
+		expect(result.stdout).toContain("--- udd status ---");
+		expect(result.stdout).toContain("--- udd status --doctor ---");
+		expect(result.stdout).toContain("--- git status --short ---");
+		expect(result.stdout).toContain("udd status");
+		expect(result.stdout).toContain("udd status --doctor");
+	});
+});
+
+test("codex hook installer preserves existing codex hooks", async () => {
+	await withExternalProject(async (rootDir) => {
+		const codexDir = path.join(rootDir, ".codex");
+		await fs.mkdir(codexDir, { recursive: true });
+		await fs.writeFile(
+			path.join(codexDir, "hooks.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: ".codex/hooks/existing.sh",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				"\t",
+			),
+		);
+
+		await installCodexHooks(rootDir);
+
+		const config = JSON.parse(
+			await fs.readFile(path.join(codexDir, "hooks.json"), "utf8"),
+		);
+
+		expect(config.hooks.UserPromptSubmit).toHaveLength(2);
+		expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			".codex/hooks/existing.sh",
+		);
+		expect(config.hooks.UserPromptSubmit[1].hooks[0].command).toBe(
+			".codex/hooks/pre-task.sh",
+		);
+	});
+});
+
+test("codex integration docs describe UDD tooling instead of goal workflow", async () => {
+	const readme = await fs.readFile(
+		path.resolve(process.cwd(), "integrations/codex/README.md"),
+		"utf8",
+	);
+
+	expect(readme).toContain(".codex/hooks.json");
+	expect(readme).toContain(".codex/hooks/pre-task.sh");
+	expect(readme).toContain("udd status");
+	expect(readme).toContain("udd status --doctor");
+	expect(readme).not.toContain("/goal");
+	expect(readme).not.toContain("goals/");
+});

--- a/tests/lib/codex-tooling.test.ts
+++ b/tests/lib/codex-tooling.test.ts
@@ -58,7 +58,6 @@ test("codex pre-task hook surfaces UDD health checks", async () => {
 			"utf8",
 		);
 
-		expect(hook).toContain("node --import tsx bin/udd.ts");
 		expect(hook).toContain("node_modules/.bin/udd");
 		expect(hook).toContain("udd status");
 		expect(hook).toContain("udd status --doctor");
@@ -149,6 +148,41 @@ test("codex hook installer preserves existing codex hooks", async () => {
 			".codex/hooks/existing.sh",
 		);
 		expect(config.hooks.UserPromptSubmit[1].hooks[0].command).toBe(
+			".codex/hooks/pre-task.sh",
+		);
+	});
+});
+
+test("codex hook installer rejects malformed hook config without force", async () => {
+	await withExternalProject(async (rootDir) => {
+		const codexDir = path.join(rootDir, ".codex");
+		await fs.mkdir(codexDir, { recursive: true });
+		await fs.writeFile(
+			path.join(codexDir, "hooks.json"),
+			JSON.stringify({ hooks: [] }),
+		);
+
+		await expect(installCodexHooks(rootDir)).rejects.toThrow(
+			"unsupported hooks field",
+		);
+	});
+});
+
+test("codex hook installer can replace malformed hook config with force", async () => {
+	await withExternalProject(async (rootDir) => {
+		const codexDir = path.join(rootDir, ".codex");
+		await fs.mkdir(codexDir, { recursive: true });
+		await fs.writeFile(
+			path.join(codexDir, "hooks.json"),
+			JSON.stringify({ hooks: [] }),
+		);
+
+		await installCodexHooks(rootDir, { force: true });
+
+		const config = JSON.parse(
+			await fs.readFile(path.join(codexDir, "hooks.json"), "utf8"),
+		);
+		expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
 			".codex/hooks/pre-task.sh",
 		);
 	});


### PR DESCRIPTION
## Summary
- add `udd hooks install-codex` to install Codex session hooks into external UDD projects
- add `udd init --codex-hooks` for opt-in installation during project initialization
- preserve existing Codex hooks while adding UDD status diagnostics, with project-local `node_modules/.bin/udd` support

## Validation
- `npm test -- tests/lib/codex-tooling.test.ts tests/e2e/udd/cli/codex_hooks.e2e.test.ts`
- `npx tsc --noEmit`
- `npx biome check bin/udd.ts integrations/codex/README.md src/commands/hooks.ts src/commands/init.ts src/lib/codex-hooks.ts tests/lib/codex-tooling.test.ts specs/features/udd/cli/codex_hooks.feature tests/e2e/udd/cli/codex_hooks.e2e.test.ts`
- `git diff --cached --check`

Supersedes #45 for the narrow Codex hook installer scope. The broader side-branch stack in #45 is intentionally left unmerged for separate audit.
