### PR TITLE
Add PR #45 stack audit goals and report

### DIFF
--- a/docs/project/pr45-side-branch-stack-audit.md
+++ b/docs/project/pr45-side-branch-stack-audit.md
@@ -32,6 +32,8 @@ gh pr view 41 --json number,title,state,baseRefName,headRefName,mergedAt,url
 gh pr view 42 --json number,title,state,baseRefName,headRefName,mergedAt,url
 gh pr view 43 --json number,title,state,baseRefName,headRefName,mergedAt,url
 gh pr view 44 --json number,title,state,baseRefName,headRefName,mergedAt,url
+gh pr view 35 --json number,title,state,url,headRefName,baseRefName,mergeStateStatus,body
+gh pr view 40 --json number,title,state,url,headRefName,baseRefName,mergeStateStatus,body
 git log --oneline origin/master..origin/codex/source-of-truth-cleanup-base
 git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base
 git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
@@ -42,6 +44,10 @@ git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
 - PR #45: closed, head `codex/agent-integration-utilities`, base `master`.
 - PR #46: merged to `master`; Codex hook installer work is no longer part of
   the unresolved stack.
+- PR #35: closed during this audit as a stale broad Phase 2 stack PR targeting
+  `master`; branch preserved.
+- PR #40: closed during this audit as a stale side-branch cleanup PR; branch
+  preserved.
 - PRs #41-#44: merged, but into `codex/source-of-truth-cleanup-base`, not
   directly into `master`.
 - Issue #47: open tracking issue for this audit.
@@ -232,6 +238,7 @@ Each issue references this report and the exact source branch:
 ## Current Completion State
 
 - PR #46 is merged.
-- No broad side-branch merge PR is open.
+- No broad side-branch merge PR is open; stale PRs #35 and #40 were closed as
+  superseded with branches preserved.
 - This audit report covers all 265 files by classification group.
 - Follow-up issues #49-#56 cover the still-valuable groups and tooling decisions.

--- a/docs/project/pr45-side-branch-stack-audit.md
+++ b/docs/project/pr45-side-branch-stack-audit.md
@@ -1,0 +1,237 @@
+# PR #45 Side-Branch Stack Audit
+
+Date: 2026-05-19
+
+## Summary
+
+PR #45 was correctly closed as superseded. It was not a narrow Codex hook PR; it
+was a broad integration of the `codex/source-of-truth-cleanup-base` stack plus
+later Codex work. The Codex hook work has since landed through PR #46, so the
+remaining task is to preserve and split the useful work from the side branch
+without merging the entire stack.
+
+This report classifies 100% of the current side-branch delta from
+`origin/master...origin/codex/source-of-truth-cleanup-base`: 265 changed files.
+
+## Branches Inspected
+
+- `origin/master`
+- `origin/codex/source-of-truth-cleanup-base`
+- `origin/codex/agent-integration-utilities`
+
+## Commands Run
+
+```bash
+git fetch origin
+git status --short --branch
+gh issue view 47 --json number,title,state,url,body
+gh pr view 45 --json number,title,state,url,headRefName,baseRefName
+gh pr view 46 --json number,title,state,url,headRefName,baseRefName,mergeStateStatus
+gh pr list --state merged --limit 30 --json number,title,mergedAt,headRefName
+gh pr view 41 --json number,title,state,baseRefName,headRefName,mergedAt,url
+gh pr view 42 --json number,title,state,baseRefName,headRefName,mergedAt,url
+gh pr view 43 --json number,title,state,baseRefName,headRefName,mergedAt,url
+gh pr view 44 --json number,title,state,baseRefName,headRefName,mergedAt,url
+git log --oneline origin/master..origin/codex/source-of-truth-cleanup-base
+git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base
+git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
+```
+
+## Current PR State
+
+- PR #45: closed, head `codex/agent-integration-utilities`, base `master`.
+- PR #46: merged to `master`; Codex hook installer work is no longer part of
+  the unresolved stack.
+- PRs #41-#44: merged, but into `codex/source-of-truth-cleanup-base`, not
+  directly into `master`.
+- Issue #47: open tracking issue for this audit.
+
+## File Groups and Classification
+
+The full delta is grouped below. These groups cover every file reported by
+`git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base`.
+
+| Group | Count | Status | Decision |
+| --- | ---: | --- | --- |
+| Agent integration and runtime tooling | 14 | 7 modified, 7 added | Salvage selectively after PR #46 compatibility review |
+| Architecture and process documentation | 22 | 4 modified, 18 added | Salvage in documentation-only slices |
+| BDD feature specifications | 68 | 26 modified, 41 added, 1 deleted | Salvage only with matching implementation/test slice |
+| CLI and library implementation | 28 | 13 modified, 15 added | Split into multiple feature PRs |
+| Examples and sample products | 9 | 1 deleted, 5 added, 3 renamed | Salvage after docs/source-of-truth decision |
+| Generated/local/tool state requiring caution | 3 | 3 added | Do not merge as-is |
+| Goal planning artifacts | 5 | 5 added | Superseded by current goal flow; reconcile manually |
+| Package and tooling config | 4 | 4 modified | Salvage only when required by a focused PR |
+| Product source-of-truth and traceability model | 50 | 38 added, 12 modified | Highest-value salvage, but must be first-class PR |
+| Project issue notes and stale scratch docs | 4 | 3 modified, 1 deleted | Mostly abandon or archive |
+| Repo automation and developer gates | 5 | 4 added, 1 modified | Salvage only after local checks are stable |
+| Test implementation and setup | 53 | 21 modified, 31 added, 1 deleted | Salvage with corresponding spec/implementation PRs |
+
+Total: 265 files.
+
+## Already-Landed Work
+
+- Codex hook installation support landed in PR #46 and should not be salvaged
+  again from `codex/agent-integration-utilities`.
+- PRs #36-#39 are already on `master` and should be treated as baseline.
+- PRs #41-#44 are merged only into the preserved side branch. They remain
+  source evidence, not `master` state.
+
+## Valuable Work to Salvage
+
+### 1. Product Source-of-Truth and Traceability Model
+
+Files include `product/`, `specs/roadmap.yml`, `specs/system-boundary.yml`,
+`specs/traceability-contract.yml`, `specs/journey-map.schema.yml`, and expanded
+`specs/use-cases/`.
+
+Decision: salvage first. This is the highest-leverage work because it defines
+the repo-native source-of-truth model that later CLI and test-governance work
+depends on.
+
+Required next slice:
+
+- Create a focused PR that introduces the product/source-of-truth structure and
+  roadmap/traceability docs without also adding large CLI behavior.
+- Validate that `udd status`, `udd lint`, and existing tests still pass or
+  document baseline failures clearly.
+
+### 2. Architecture and Process Documentation
+
+Files include `ARCHITECTURE.md`, `docs/architecture/*`, `docs/process/*`, and
+`docs/testing/troubleshooting-stubs.md`.
+
+Decision: salvage in one or more docs-only PRs after source-of-truth structure is
+settled. These docs are valuable but too broad to merge with implementation.
+
+### 3. CLI and Library Implementation
+
+Files include `src/commands/doctor.ts`, `src/commands/health.ts`,
+`src/commands/opencode.ts`, `src/commands/orchestrate.ts`,
+`src/commands/phase.ts`, `src/lib/phase.ts`, `src/lib/gate.ts`,
+`src/lib/test-governance.ts`, `src/lib/agent-integration.ts`, and related
+changes to `status`, `sync`, `test`, and `validate`.
+
+Decision: split into independent PRs. The stack contains several products:
+doctor/health recovery, phase/traceability, test governance, OpenCode tools, and
+orchestration. Merging them together would recreate the PR #45 problem.
+
+### 4. BDD Feature Specifications and Tests
+
+Files include 68 feature specs and 53 test files.
+
+Decision: salvage only when paired with the corresponding implementation slice.
+Spec-only or test-only imports from this branch risk creating traceability drift
+or masking stubbed behavior.
+
+### 5. Agent Integration and Runtime Tooling
+
+Files include `.opencode/*`, `integrations/*`, and shared integration contract
+docs.
+
+Decision: salvage selectively. The shared integration concepts are valuable, but
+Codex-specific goal-command ideas must not be reintroduced into the hook work.
+OpenCode-specific hooks should be treated like installable integration tooling,
+not root-local project state, unless the repo explicitly dogfoods them.
+
+### 6. Examples and Sample Products
+
+Files include `examples/`, moved feature examples, and the todo-app sample
+product.
+
+Decision: salvage after the source-of-truth layout is accepted. These are useful
+for onboarding and dogfooding, but they should not lead the stack merge.
+
+## Work to Abandon or Recreate
+
+- `.memsearch.yaml`: local/search tooling state. Do not merge unless a separate
+  repo-wide tooling decision justifies it.
+- `.udd/config.yml`: generated/project-local UDD config. Recreate through
+  documented `udd init` or config work instead of cherry-picking blindly.
+- `bun.lock`: do not merge unless the repo intentionally adopts Bun as a package
+  manager. Current `master` uses npm lockfiles.
+- `DRAFT_PR_SUMMARY_EDGE_CASE_HARDENING.md`: stale scratch summary. Do not merge
+  as a root-level artifact.
+- Root-local `.opencode/hooks/pre-task.sh`: do not merge as a local hook unless
+  the integration is explicitly installable or the repo dogfooding contract says
+  it belongs in source.
+- Stub-only tests from the stack: do not merge if their only purpose is to move
+  metrics without implementing or honestly classifying behavior.
+
+## Proposed PR Sequence
+
+1. Product source-of-truth and roadmap foundation.
+   - Pull from: `product/`, `specs/roadmap.yml`, `specs/system-boundary.yml`,
+     `specs/traceability-contract.yml`, `specs/journey-map.*`,
+     `specs/use-cases/*`.
+   - Exclude generated `.udd/config.yml` unless recreated intentionally.
+
+2. Architecture/process docs alignment.
+   - Pull from: `ARCHITECTURE.md`, `docs/architecture/*`, `docs/process/*`, and
+     `docs/testing/troubleshooting-stubs.md`.
+   - Keep as docs-only unless a broken link or command requires a tiny support
+     edit.
+
+3. Phase and traceability CLI foundation.
+   - Pull from: `src/lib/phase.ts`, `src/lib/trace.ts`, `src/lib/paths.ts`,
+     `src/commands/phase.ts`, and related type/schema changes.
+   - Include only the feature specs/tests needed for this behavior.
+
+4. Doctor and health diagnostics.
+   - Pull from: `src/commands/doctor.ts`, `src/commands/health.ts`, relevant
+     status/sync support, and matching recovery/diagnostic specs.
+   - Validate against real initialized and drifted temp projects.
+
+5. Test-governance gates.
+   - Pull from: `src/lib/test-governance.ts`, hook/gate behavior, CI workflow
+     drafts, and matching specs/tests.
+   - Do not merge CI gates until local commands are stable and non-flaky.
+
+6. OpenCode/shared agent integration.
+   - Pull from: `integrations/shared/*`, `integrations/opencode/*`,
+     `.opencode/command/*`, and `.opencode/plugin/*`.
+   - Keep Codex hook behavior aligned with PR #46 and avoid Codex goal-command
+     coupling.
+
+7. Examples and sample products.
+   - Pull from: `examples/*` and moved `docs/example-features/*`.
+   - Merge after the canonical product/spec layout is stable.
+
+8. Package/tooling cleanup.
+   - Decide separately on Biome config, package scripts, `lefthook.yml`, and CI.
+   - Do not merge `bun.lock` unless package-manager policy changes.
+
+## Follow-Up Tracking
+
+The proposed PR sequence is tracked by focused follow-up issues:
+
+- #49: Salvage PR #45 source-of-truth foundation.
+- #50: Salvage PR #45 architecture and process docs.
+- #51: Salvage PR #45 phase and traceability CLI foundation.
+- #52: Salvage PR #45 doctor and health diagnostics.
+- #55: Salvage PR #45 test-governance gates.
+- #54: Salvage PR #45 OpenCode and shared agent integration.
+- #53: Salvage PR #45 examples and sample products.
+- #56: Decide PR #45 package and tooling cleanup.
+
+Each issue references this report and the exact source branch:
+`origin/codex/source-of-truth-cleanup-base`.
+
+## Risks and Validation Gaps
+
+- The side branch contains many stub and governance tests. Each test must be
+  evaluated against the real behavior it claims to verify.
+- Some docs describe future architecture rather than current implementation.
+  Those docs need either explicit "future" framing or matching implementation.
+- The side branch contains root-local agent/tool state. That state should be
+  converted into installable tooling or excluded.
+- Broad validation commands may expose pre-existing failures. Each follow-up PR
+  must distinguish baseline debt from regressions caused by the slice.
+- `origin/master` moved during this audit when PR #46 merged. Future execution
+  should fetch and rebase before creating salvage branches.
+
+## Current Completion State
+
+- PR #46 is merged.
+- No broad side-branch merge PR is open.
+- This audit report covers all 265 files by classification group.
+- Follow-up issues #49-#56 cover the still-valuable groups and tooling decisions.

--- a/docs/project/reviews/2026-05-19-pr45-stack-audit/report.md
+++ b/docs/project/reviews/2026-05-19-pr45-stack-audit/report.md
@@ -10,14 +10,22 @@ later Codex work. The Codex hook work has since landed through PR #46, so the
 remaining task is to preserve and split the useful work from the side branch
 without merging the entire stack.
 
-This report classifies 100% of the current side-branch delta from
-`origin/master...origin/codex/source-of-truth-cleanup-base`: 265 changed files.
+This report classifies 100% of the current side-branch delta from the
+repository default branch to `origin/codex/source-of-truth-cleanup-base`.
+GitHub reports the default branch as `master` as of 2026-05-19, so the concrete
+comparison is `origin/master...origin/codex/source-of-truth-cleanup-base`: 265
+changed files.
 
 ## Branches Inspected
 
 - `origin/master`
 - `origin/codex/source-of-truth-cleanup-base`
 - `origin/codex/agent-integration-utilities`
+
+Note: `specs/VISION.md` currently describes `main`, but this is not the current
+GitHub default branch and there is no `origin/main` remote branch. The next
+source-of-truth increment must reconcile that drift instead of using commands
+that target a missing branch.
 
 ## Commands Run
 
@@ -34,6 +42,7 @@ gh pr view 43 --json number,title,state,baseRefName,headRefName,mergedAt,url
 gh pr view 44 --json number,title,state,baseRefName,headRefName,mergedAt,url
 gh pr view 35 --json number,title,state,url,headRefName,baseRefName,mergeStateStatus,body
 gh pr view 40 --json number,title,state,url,headRefName,baseRefName,mergeStateStatus,body
+gh repo view rothnic/udd --json defaultBranchRef
 git log --oneline origin/master..origin/codex/source-of-truth-cleanup-base
 git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base
 git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
@@ -51,6 +60,7 @@ git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
 - PRs #41-#44: merged, but into `codex/source-of-truth-cleanup-base`, not
   directly into `master`.
 - Issue #47: open tracking issue for this audit.
+- Repository default branch: `master` as reported by GitHub on 2026-05-19.
 
 ## File Groups and Classification
 
@@ -81,6 +91,9 @@ Total: 265 files.
 - PRs #36-#39 are already on `master` and should be treated as baseline.
 - PRs #41-#44 are merged only into the preserved side branch. They remain
   source evidence, not `master` state.
+- `specs/VISION.md` branch naming is stale relative to GitHub's default branch;
+  issue #49 and `goals/006-source-of-truth-foundation.md` now make that an
+  explicit source-of-truth reconciliation item.
 
 ## Valuable Work to Salvage
 
@@ -234,6 +247,9 @@ Each issue references this report and the exact source branch:
   must distinguish baseline debt from regressions caused by the slice.
 - `origin/master` moved during this audit when PR #46 merged. Future execution
   should fetch and rebase before creating salvage branches.
+- Branch naming is inconsistent across repo docs. Use the GitHub default branch
+  as the command source of truth until the source-of-truth increment resolves the
+  `main` vs `master` policy.
 
 ## Current Completion State
 
@@ -242,3 +258,5 @@ Each issue references this report and the exact source branch:
   superseded with branches preserved.
 - This audit report covers all 265 files by classification group.
 - Follow-up issues #49-#56 cover the still-valuable groups and tooling decisions.
+- The next executable increment is defined in
+  `goals/006-source-of-truth-foundation.md`.

--- a/goals/005-pr45-side-branch-stack-audit.md
+++ b/goals/005-pr45-side-branch-stack-audit.md
@@ -1,0 +1,170 @@
+# Goal: Audit and Salvage the PR #45 Side-Branch Stack
+
+## Agent Entry
+
+- Goal file: `goals/005-pr45-side-branch-stack-audit.md`
+- Tracking issue: `#47`
+- Source branches:
+  - `origin/codex/source-of-truth-cleanup-base`
+  - `origin/codex/agent-integration-utilities`
+- PR target: one or more focused PRs to `master`; do not reopen a broad stack PR.
+
+## Objective
+
+Determine exactly which work from the superseded PR #45 side-branch stack should
+land on `master`, which work is already represented by merged PRs, and which work
+should be abandoned. By the end of the long session, every valuable change from
+the preserved stack must either be merged, waiting in a focused PR for final
+approval, or explicitly deferred with a follow-up issue/goal.
+
+## Context
+
+PR #45 was closed because it mixed a narrow Codex hook installer change with a
+much larger side-branch stack. The hook work was extracted into PR #46. The
+remaining stack still needs deliberate review so useful progress is not lost.
+
+Known facts to preserve:
+
+- PRs #36-#39 are already merged to `master`.
+- PRs #41-#44 were merged into `codex/source-of-truth-cleanup-base`, not
+  directly into `master`.
+- `origin/codex/source-of-truth-cleanup-base` differs from `master` by roughly
+  265 files and includes source-of-truth, phase, docs, specs, tests, and agent
+  integration work.
+- `origin/codex/agent-integration-utilities` includes that broader stack plus
+  the later Codex hook work.
+- Do not promote the full stack into `master` without splitting and reviewing it.
+
+## Scope
+
+In scope:
+
+- Build a source-of-truth inventory of the stack delta against `master`.
+- Classify each change group as already landed, still valuable, obsolete, or
+  unsafe/stale.
+- Split still-valuable work into PR-sized goal files or implementation branches.
+- Merge or prepare focused PRs for the highest-value slices that are safe to
+  land during the session.
+- Preserve exact evidence for abandoned or deferred work.
+
+Out of scope:
+
+- Reopening PR #45 as a broad integration PR.
+- Force-pushing or deleting preserved branches before the audit is complete.
+- Reintroducing Codex goal workflows as part of Codex hook/tooling work.
+- Merging generated state, local agent state, or one-off scratch files without a
+  clear source-of-truth reason.
+
+## Required Inputs
+
+- GitHub:
+  - `gh issue view 47`
+  - `gh pr view 45`
+  - `gh pr view 46`
+  - `gh pr list --state merged --limit 30`
+- Git comparisons:
+  - `git log --oneline origin/master..origin/codex/source-of-truth-cleanup-base`
+  - `git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base`
+  - `git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base`
+  - `git range-diff origin/master...origin/codex/source-of-truth-cleanup-base`
+- Existing source-of-truth docs:
+  - `AGENTS.md`
+  - `README.md`
+  - `specs/VISION.md`
+  - `specs/.udd/manifest.yml`
+  - `docs/project/`
+
+## Workstreams
+
+1. Baseline the current `master` state.
+2. Inventory the full side-branch delta and group files by subsystem.
+3. Reconcile already-merged work from PRs #36-#39 against the side-branch stack.
+4. Classify remaining work into these buckets:
+   - Source-of-truth and roadmap cleanup.
+   - Traceability and phase model.
+   - UDD CLI behavior.
+   - Test governance and validation gates.
+   - Agent integration and runtime-specific tooling.
+   - Docs/examples/product/spec organization.
+   - Generated, local, stale, or unsafe artifacts.
+5. For each valuable bucket, create a PR-sized plan with explicit acceptance
+   checks before implementing or cherry-picking.
+6. Implement only the safest, highest-leverage slices during the session.
+7. Leave remaining valid work as follow-up goal files or GitHub issues with
+   branch/file evidence.
+
+## Required Audit Artifact
+
+Create or update a durable audit report before opening implementation PRs:
+
+- Preferred path: `docs/project/pr45-side-branch-stack-audit.md`
+- The report must include:
+  - Branches inspected.
+  - Commands run.
+  - File groups and classification.
+  - Already-landed work.
+  - Valuable work to salvage.
+  - Work to abandon and why.
+  - Proposed PR sequence.
+  - Risks and validation gaps.
+
+## Explicit Checks
+
+The goal is complete only when all of these are true:
+
+- [ ] PR #46 is either merged or explicitly excluded from this stack audit.
+- [ ] The audit report exists at `docs/project/pr45-side-branch-stack-audit.md`.
+- [ ] Every file changed by `origin/master...origin/codex/source-of-truth-cleanup-base`
+      is covered by a classification group in the audit report.
+- [ ] Every still-valuable group is either merged, in an open focused PR, or
+      represented by a follow-up goal/issue with exact branch and file evidence.
+- [ ] No broad side-branch merge PR is open.
+- [ ] No generated/local agent state is proposed for merge unless justified in
+      the audit report.
+- [ ] Each implementation PR produced from this goal has its own scoped tests,
+      review notes, and clear rollback/defer decision.
+
+## Measurables
+
+- Stack inventory coverage: 100% of changed files grouped.
+- Merge readiness: each open PR from this goal must be `CLEAN` or have a
+  documented blocker.
+- Scope control: no follow-up PR should exceed one coherent subsystem unless the
+  audit report explains why the files cannot be split safely.
+- Preservation: no branch deletion or destructive history rewrite until all
+  valuable work is merged or tracked elsewhere.
+
+## Verification Commands
+
+Run these at the start:
+
+```bash
+git fetch origin
+git status --short --branch
+gh issue view 47
+git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base
+git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
+```
+
+Run these before each implementation PR:
+
+```bash
+npm test
+npx tsc --noEmit
+npx biome check .
+```
+
+If a verification command is too broad, unavailable, or fails because of known
+baseline debt, record the exact failure and run the narrowest command that covers
+the changed files.
+
+## Completion Handoff
+
+The final response or PR summary must include:
+
+- The audit report path.
+- PRs opened or merged.
+- Follow-up issues/goals created.
+- Work intentionally abandoned.
+- Validation commands and results.
+- The next exact goal file or command to run.

--- a/goals/005-pr45-side-branch-stack-audit.md
+++ b/goals/005-pr45-side-branch-stack-audit.md
@@ -7,15 +7,17 @@
 - Source branches:
   - `origin/codex/source-of-truth-cleanup-base`
   - `origin/codex/agent-integration-utilities`
-- PR target: one or more focused PRs to `master`; do not reopen a broad stack PR.
+- PR target: one or more focused PRs to the repository default branch
+  (`master` on GitHub as of 2026-05-19); do not reopen a broad stack PR.
 
 ## Objective
 
 Determine exactly which work from the superseded PR #45 side-branch stack should
-land on `master`, which work is already represented by merged PRs, and which work
-should be abandoned. By the end of the long session, every valuable change from
-the preserved stack must either be merged, waiting in a focused PR for final
-approval, or explicitly deferred with a follow-up issue/goal.
+land on the repository default branch, which work is already represented by
+merged PRs, and which work should be abandoned. By the end of the long session,
+every valuable change from the preserved stack must either be merged, waiting in
+a focused PR for final approval, or explicitly deferred with a follow-up
+issue/goal.
 
 ## Context
 
@@ -25,21 +27,27 @@ remaining stack still needs deliberate review so useful progress is not lost.
 
 Known facts to preserve:
 
-- PRs #36-#39 are already merged to `master`.
+- PRs #36-#39 are already merged to the repository default branch.
 - PRs #41-#44 were merged into `codex/source-of-truth-cleanup-base`, not
-  directly into `master`.
-- `origin/codex/source-of-truth-cleanup-base` differs from `master` by roughly
-  265 files and includes source-of-truth, phase, docs, specs, tests, and agent
-  integration work.
+  directly into the default branch.
+- GitHub reports the repository default branch as `master` as of 2026-05-19.
+  `specs/VISION.md` still describes `main`; treat that as source-of-truth drift
+  to reconcile in the source-of-truth follow-up, not as proof that `origin/main`
+  exists.
+- `origin/codex/source-of-truth-cleanup-base` differs from the default branch by
+  roughly 265 files and includes source-of-truth, phase, docs, specs, tests, and
+  agent integration work.
 - `origin/codex/agent-integration-utilities` includes that broader stack plus
   the later Codex hook work.
-- Do not promote the full stack into `master` without splitting and reviewing it.
+- Do not promote the full stack into the default branch without splitting and
+  reviewing it.
 
 ## Scope
 
 In scope:
 
-- Build a source-of-truth inventory of the stack delta against `master`.
+- Build a source-of-truth inventory of the stack delta against the default
+  branch.
 - Classify each change group as already landed, still valuable, obsolete, or
   unsafe/stale.
 - Split still-valuable work into PR-sized goal files or implementation branches.
@@ -62,11 +70,13 @@ Out of scope:
   - `gh pr view 45`
   - `gh pr view 46`
   - `gh pr list --state merged --limit 30`
+  - `gh repo view rothnic/udd --json defaultBranchRef`
 - Git comparisons:
-  - `git log --oneline origin/master..origin/codex/source-of-truth-cleanup-base`
-  - `git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base`
-  - `git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base`
-  - `git range-diff origin/master...origin/codex/source-of-truth-cleanup-base`
+  - `DEFAULT_BRANCH=$(gh repo view rothnic/udd --json defaultBranchRef --jq .defaultBranchRef.name)`
+  - `git log --oneline origin/$DEFAULT_BRANCH..origin/codex/source-of-truth-cleanup-base`
+  - `git diff --name-status origin/$DEFAULT_BRANCH...origin/codex/source-of-truth-cleanup-base`
+  - `git diff --stat origin/$DEFAULT_BRANCH...origin/codex/source-of-truth-cleanup-base`
+  - `git range-diff origin/$DEFAULT_BRANCH...origin/codex/source-of-truth-cleanup-base`
 - Existing source-of-truth docs:
   - `AGENTS.md`
   - `README.md`
@@ -76,7 +86,7 @@ Out of scope:
 
 ## Workstreams
 
-1. Baseline the current `master` state.
+1. Baseline the current default-branch state.
 2. Inventory the full side-branch delta and group files by subsystem.
 3. Reconcile already-merged work from PRs #36-#39 against the side-branch stack.
 4. Classify remaining work into these buckets:
@@ -97,7 +107,7 @@ Out of scope:
 
 Create or update a durable audit report before opening implementation PRs:
 
-- Preferred path: `docs/project/pr45-side-branch-stack-audit.md`
+- Preferred path: `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
 - The report must include:
   - Branches inspected.
   - Commands run.
@@ -113,9 +123,11 @@ Create or update a durable audit report before opening implementation PRs:
 The goal is complete only when all of these are true:
 
 - [ ] PR #46 is either merged or explicitly excluded from this stack audit.
-- [ ] The audit report exists at `docs/project/pr45-side-branch-stack-audit.md`.
-- [ ] Every file changed by `origin/master...origin/codex/source-of-truth-cleanup-base`
-      is covered by a classification group in the audit report.
+- [ ] The audit report exists at
+      `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`.
+- [ ] Every file changed between the repository default branch and
+      `origin/codex/source-of-truth-cleanup-base` is covered by a classification
+      group in the audit report.
 - [ ] Every still-valuable group is either merged, in an open focused PR, or
       represented by a follow-up goal/issue with exact branch and file evidence.
 - [ ] No broad side-branch merge PR is open.
@@ -142,8 +154,10 @@ Run these at the start:
 git fetch origin
 git status --short --branch
 gh issue view 47
-git diff --stat origin/master...origin/codex/source-of-truth-cleanup-base
-git diff --name-status origin/master...origin/codex/source-of-truth-cleanup-base
+gh repo view rothnic/udd --json defaultBranchRef
+DEFAULT_BRANCH=$(gh repo view rothnic/udd --json defaultBranchRef --jq .defaultBranchRef.name)
+git diff --stat origin/$DEFAULT_BRANCH...origin/codex/source-of-truth-cleanup-base
+git diff --name-status origin/$DEFAULT_BRANCH...origin/codex/source-of-truth-cleanup-base
 ```
 
 Run these before each implementation PR:

--- a/goals/006-source-of-truth-foundation.md
+++ b/goals/006-source-of-truth-foundation.md
@@ -1,0 +1,123 @@
+# Goal: Source-of-Truth Foundation Salvage
+
+## Agent Entry
+
+- Goal file: `goals/006-source-of-truth-foundation.md`
+- Tracking issue: `#49`
+- Source branch: `origin/codex/source-of-truth-cleanup-base`
+- Audit report: `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
+- PR target: repository default branch (`master` on GitHub as of 2026-05-19)
+
+## Objective
+
+Land the first focused salvage increment from the PR #45 side-branch stack:
+the product/source-of-truth foundation. The result should give UDD a coherent
+repo-native product intent layer and roadmap/traceability foundation without
+also importing broad CLI, test-governance, OpenCode, or generated local-state
+changes.
+
+## Context
+
+The PR #45 audit classified product/source-of-truth and traceability model work
+as the highest-value first salvage slice. This goal executes that first slice
+only.
+
+Important branch fact:
+
+- GitHub currently reports the default branch as `master`.
+- `specs/VISION.md` still describes `main`; reconcile that drift in this goal
+  by either updating the document to the actual branch name or explicitly
+  documenting a planned branch rename. Do not write commands that require
+  `origin/main` unless the remote branch exists.
+
+## Scope
+
+In scope:
+
+- Product intent files from the side branch:
+  - `product/README.md`
+  - `product/actors.md`
+  - `product/concept.md`
+  - `product/constraints.md`
+  - `product/journeys/*.md`
+- Traceability and roadmap foundation files:
+  - `specs/roadmap.yml`
+  - `specs/system-boundary.yml`
+  - `specs/traceability-contract.yml`
+  - `specs/journey-map.schema.yml`
+  - `specs/journey-map.example.yml`
+  - `specs/requirements/persist_inbox_item.yml`
+  - `specs/trace-slices/capture-ideas-inbox.md`
+  - relevant `specs/use-cases/*.yml` updates
+- Minimal docs or README edits needed to explain the new source-of-truth layer.
+- Reconciliation of the `main` vs `master` branch-name drift in `specs/VISION.md`
+  or a clearly documented follow-up decision.
+
+Out of scope:
+
+- `src/commands/*` or `src/lib/*` implementation changes beyond a tiny
+  compatibility edit required by existing tests.
+- `docs/architecture/*`, `docs/process/*`, and examples. Those are tracked by
+  #50 and #53.
+- `.udd/config.yml`, `.memsearch.yaml`, `bun.lock`, root-local agent state, or
+  generated/local tooling artifacts.
+- OpenCode/shared integration work from #54.
+- Test-governance, doctor, health, phase CLI, or CI gate work from #51, #52,
+  #55, and #56.
+
+## Tasks
+
+1. Fetch and confirm the default branch:
+   `gh repo view rothnic/udd --json defaultBranchRef`.
+2. Create a fresh branch from the current default branch.
+3. Cherry-pick or copy only the in-scope source-of-truth files from
+   `origin/codex/source-of-truth-cleanup-base`.
+4. Review every imported file for stale references, generated state, and branch
+   naming drift.
+5. Run scoped validation and fix only issues caused by this slice.
+6. Open one focused PR that references #49 and this goal file.
+
+## Explicit Checks
+
+The goal is complete only when these are true:
+
+- [ ] The PR diff excludes generated/local artifacts such as `.udd/config.yml`,
+      `.memsearch.yaml`, and `bun.lock`.
+- [ ] The PR diff excludes broad CLI/test-governance/OpenCode implementation
+      changes.
+- [ ] Product intent and roadmap/traceability files are internally consistent.
+- [ ] `specs/VISION.md` no longer conflicts silently with the repository's
+      actual default branch.
+- [ ] Each imported journey/use-case file is either referenced by the roadmap or
+      explicitly marked as backlog/future.
+- [ ] Validation output is recorded in the PR body.
+- [ ] Any deferred source-of-truth decisions are linked to an exact issue or goal.
+
+## Verification Commands
+
+Run:
+
+```bash
+git fetch origin
+gh repo view rothnic/udd --json defaultBranchRef
+DEFAULT_BRANCH=$(gh repo view rothnic/udd --json defaultBranchRef --jq .defaultBranchRef.name)
+git diff --name-status origin/$DEFAULT_BRANCH...HEAD
+npm run udd -- status
+npm run udd -- lint
+npx tsc --noEmit
+```
+
+If `npm run udd -- status` or `npm run udd -- lint` fails because the imported
+source-of-truth files expose pre-existing baseline drift, record the exact
+failure and add a follow-up issue instead of suppressing it.
+
+## PR Notes
+
+The PR body must include:
+
+- Objective and issue link: #49.
+- Files imported from `origin/codex/source-of-truth-cleanup-base`.
+- Files intentionally excluded and why.
+- Branch-name reconciliation decision.
+- Validation commands and results.
+- Next recommended issue after merge.

--- a/goals/README.md
+++ b/goals/README.md
@@ -1,0 +1,19 @@
+# Goals
+
+This directory contains source-controlled goals for agent-executed project work.
+Goals are not tied to a specific agent vendor. A goal should be complete enough
+that a human or agent can start from the file path, execute the work, verify the
+checks, and prepare focused PRs.
+
+## How To Use
+
+1. Pick the first open goal in numeric order.
+2. Give the agent the goal path.
+3. Execute only the work described by that goal.
+4. Run the explicit checks and record any deferred work by issue or goal path.
+
+## Files
+
+- `005-pr45-side-branch-stack-audit.md`: audit the broad stack preserved after
+  superseded PR #45 and split valid work into mergeable slices.
+

--- a/goals/README.md
+++ b/goals/README.md
@@ -16,4 +16,5 @@ checks, and prepare focused PRs.
 
 - `005-pr45-side-branch-stack-audit.md`: audit the broad stack preserved after
   superseded PR #45 and split valid work into mergeable slices.
-
+- `006-source-of-truth-foundation.md`: execute the first salvage increment from
+  issue #49 by landing the product/source-of-truth foundation.


### PR DESCRIPTION
## Summary
- add a source-controlled long-horizon goal for auditing the broad side-branch stack from superseded PR #45
- move the completed audit report to the scoped dated review path `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
- split the remaining valuable stack work into focused follow-up issues #49-#56
- add `goals/006-source-of-truth-foundation.md` as the next executable increment for issue #49

## Review Follow-Up
- Kept `master` where it is factual evidence because GitHub currently reports the repo default branch as `master` and there is no `origin/main`.
- Updated goal commands to derive the default branch with `gh repo view ... --jq .defaultBranchRef.name` instead of hardcoding branch names for future execution.
- Added explicit branch-name drift handling to `goals/006-source-of-truth-foundation.md` so the `specs/VISION.md` `main` vs actual `master` mismatch is reconciled in the source-of-truth increment.
- Moved the report out of `docs/project/` root into the dated review directory requested by review.

## Validation
- `git diff --check`
- manual review of `goals/005-pr45-side-branch-stack-audit.md`
- manual review of `goals/006-source-of-truth-foundation.md`
- manual review of `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`

This PR does not merge or cherry-pick implementation from the side-branch stack. It adds the durable goal, audit report, and next executable goal needed to continue with focused salvage PRs.
