### PR TITLE
Add source-of-truth foundation

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -1,0 +1,18 @@
+# UDD Product
+
+User Driven Development (UDD) - A spec-first CLI tool where user journeys
+are requirements and BDD scenarios are tests.
+
+## Problem Statement
+
+Traditional development often separates requirements from implementation,
+leading to drift, unclear scope, and miscommunication between product
+and engineering.
+
+## Solution
+
+UDD bridges the gap by:
+- Treating user journeys as executable requirements
+- Auto-generating BDD scenarios from journey steps
+- Linking tests directly to product intent
+- Providing traceability from idea → spec → test → code

--- a/product/actors.md
+++ b/product/actors.md
@@ -1,0 +1,58 @@
+# Actors
+
+## Primary Actors
+
+### Developer
+- **ID**: developer
+- **Goal**: Ship features with clear traceability to product intent
+- **Pain Points**:
+  - Requirements drift from implementation
+  - Unclear what "done" means
+  - Hard to trace test failures to requirements
+
+### AI Agent
+- **ID**: agent
+- **Goal**: Assist development while respecting boundaries
+- **Pain Points**:
+  - Unclear what has human approval
+  - Hard to detect work-in-progress
+  - No structured handoff protocol
+
+### Product Manager
+- **ID**: product_manager
+- **Goal**: Communicate product vision clearly
+- **Pain Points**:
+  - Requirements lost in translation
+  - No visibility into implementation status
+  - Features shipped that don't match intent
+
+## Secondary Actors
+
+### Code Reviewer
+- **ID**: code_reviewer
+
+### QA Engineer
+- **ID**: qa_engineer
+
+### DevOps Engineer
+- **ID**: devops_engineer
+
+### Team Lead
+- **ID**: team_lead
+- **Goal**: Maintain delivery quality and keep team work aligned with product intent
+
+### Team Manager
+- **ID**: team_manager
+- **Goal**: Monitor quality, delivery health, and process risks across the team
+
+### User
+- **ID**: user
+- **Goal**: Use UDD workflows without needing to understand internal traceability mechanics
+
+### Orchestrator Agent
+- **ID**: orchestrator_agent
+- **Goal**: Coordinate multi-step agent work through UDD status and traceability signals
+
+### Worker Agent
+- **ID**: worker_agent
+- **Goal**: Complete bounded implementation tasks while preserving source-of-truth alignment

--- a/product/concept.md
+++ b/product/concept.md
@@ -1,0 +1,163 @@
+# Concept: User Driven Development (UDD)
+
+## Core Philosophy
+
+### User-First Development
+UDD inverts the traditional development pyramid. Instead of:
+```
+Code → Tests → Documentation → User Value
+```
+
+We practice:
+```
+User Journey → Scenarios → Tests → Code
+```
+
+**The user is not an afterthought—they are the specification.**
+
+### Journeys as Requirements
+A user journey is not documentation. It is a **computable requirement**. Each step in a journey:
+- Maps to a BDD scenario
+- Links to executable tests
+- Traces to implementation
+- Validates completion
+
+### Test-as-Spec
+Tests are not separate from requirements—they **are** the requirements in executable form. When all tests pass, the feature is done by definition.
+
+### Traceability as Non-Negotiable
+Every line of code must trace to a user need. Drift is detected, not tolerated.
+
+## Scope
+
+### In Scope
+
+**Core Framework**
+- Journey authoring and management
+- Scenario generation from journeys
+- Traceability validation
+- Test lifecycle management (dirty/clean marking)
+- CLI for developer workflows
+- OpenCode plugin for agent integration
+
+**Integration Points**
+- Git hooks for pre-commit validation
+- GitHub Actions for CI gates
+- VS Code extension for editor awareness
+- OpenCode orchestration hooks
+
+**Governance**
+- Phase-based development roadmap
+- Use-case traceability
+- Quality gates and checkpoints
+- Remediation workflows
+
+### Out of Scope
+
+**Not a Replacement For**
+- Project management tools (Jira, Linear)
+- Test runners (Vitest, Jest)
+- CI/CD platforms (GitHub Actions, CircleCI)
+- Documentation generators
+
+**Explicitly Excluded**
+- Test execution (delegated to test runners)
+- Code generation (scaffolding only)
+- Deployment automation
+- Bug tracking
+- Performance profiling
+
+## Success Metrics
+
+### Completeness
+- **100% journey coverage**: Every user journey has linked scenarios
+- **100% traceability**: Every scenario links to a use case
+- **100% strict validation**: `udd validate --strict` passes
+
+### Quality
+- **Zero drift**: All references resolve correctly
+- **Zero stubs**: All tests have real assertions
+- **<5 min recovery**: Drift detected and fixed automatically
+
+### Adoption
+- **Daily usage**: Team runs `udd status` daily
+- **Phase adherence**: Work respects roadmap phase boundaries
+- **Agent integration**: AI agents pause on drift
+
+## Target Users
+
+### Primary: Software Developers
+- **Need**: Clear requirements that don't drift
+- **Benefit**: Know exactly what's expected and when it's done
+- **Workflow**: Journey → Scenario → Test → Code
+
+### Secondary: AI Agents
+- **Need**: Structured context for autonomous work
+- **Benefit**: Clear boundaries, traceable decisions, guided recovery
+- **Workflow**: Status check → Guided iteration → Validation
+
+### Supporting: Product Managers
+- **Need**: Visibility into implementation status
+- **Benefit**: Requirements live in code, not documents
+- **Workflow**: Author journey → Auto-generate scenarios → Track progress
+
+### Enabling: QA Engineers
+- **Need**: Test coverage linked to requirements
+- **Benefit**: Tests validate intent, not just implementation
+- **Workflow**: Review scenarios → Add edge cases → Validate coverage
+
+## Value Hypotheses
+
+### H1: Journeys Prevent Drift
+**Claim**: When requirements are expressed as user journeys linked to executable tests, requirements drift drops by 80%.
+
+**Validation**: Track scenarios with broken references over time. Target: <5% broken.
+
+### H2: Traceability Accelerates Onboarding
+**Claim**: New developers understand the codebase 50% faster when they can trace code to user journeys.
+
+**Validation**: Measure time to first meaningful PR for new team members.
+
+### H3: Agent Integration Reduces Review Cycles
+**Claim**: AI agents with UDD context require 60% fewer review cycles.
+
+**Validation**: Compare PR iterations with/without UDD context.
+
+### H4: Strict Validation Prevents Tech Debt
+**Claim**: Enforcing traceability at commit time prevents 70% of architectural drift.
+
+**Validation**: Compare code churn in repos with/without UDD gates.
+
+## Guiding Principles
+
+1. **Spec is Truth**: If it's not in a journey, it's not a requirement.
+2. **Automation Over Process**: Manual checks become automated gates.
+3. **Fail Fast, Fix Fast**: Detect drift immediately, remediate automatically.
+4. **Dogfood Everything**: UDD must use UDD for its own development.
+5. **Agent-Ready**: Design for AI agents as first-class users.
+
+## Anti-Patterns
+
+- ✗ Skipping validation to "save time"
+- ✗ Writing code before scenarios
+- ✗ Treating journeys as documentation-only
+- ✗ Allowing broken references to persist
+- ✗ Disabling gates to merge faster
+
+## Evolution
+
+UDD evolves through phases:
+
+**Phase 1**: Core CLI and validation (COMPLETE)
+**Phase 2**: Research and technical specs (COMPLETE)
+**Phase 3**: OpenCode integration (CURRENT)
+**Phase 4**: Agent intelligence (UPCOMING)
+**Phase 5**: Advanced workflows (UPCOMING)
+
+Each phase adds capability while maintaining strict backward compatibility for existing journeys and scenarios.
+
+## Conclusion
+
+UDD is not a tool—it's a contract between humans and machines. The contract states:
+
+> *"Every piece of code exists to serve a user need. That need is documented in a journey, specified in scenarios, verified by tests, and traceable at all times. Drift is not tolerated. Quality is not optional. The user is the north star."*

--- a/product/constraints.md
+++ b/product/constraints.md
@@ -1,0 +1,19 @@
+# Constraints
+
+## Non-Functional Requirements
+
+### Performance
+- CLI commands must complete in < 2 seconds
+- Sync operation must handle 100 journeys in < 30 seconds
+
+### Reliability
+- Zero false positives in traceability validation
+- Graceful degradation when files are missing
+
+### Usability
+- Commands must be discoverable via --help
+- Error messages must suggest fixes
+
+### Compatibility
+- Support Node.js 18+
+- Support Windows, macOS, Linux

--- a/product/journeys/agent-customization.md
+++ b/product/journeys/agent-customization.md
@@ -1,0 +1,33 @@
+# Journey: Agent Customization
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Configure agent adapters to use shared UDD workflow guidance
+
+## Context
+
+Agent runtimes need context about UDD to assist effectively. This journey
+ensures Codex, OpenCode, and future adapters can access project status and guide
+users through the same source-of-truth workflow.
+
+## Steps
+
+1. Developer opens an agent adapter
+2. Agent has access to `udd status` output → `specs/features/udd/agent/status_prompt.feature`
+3. Agent guides user through UDD process → `specs/features/udd/agent/guide_user.feature`
+4. Codex hooks can be installed into external projects → `specs/features/udd/cli/codex_hooks.feature`
+5. User gets contextual assistance
+
+## Future Steps
+
+- OpenCode adapter deep-status, next-recommendation, and issue-list tooling is deferred to #54.
+
+## Success Criteria
+
+- Agent has access to project status
+- Agent can guide users through UDD workflow
+- Assistance is contextual and helpful
+
+## Use Cases
+
+- `specs/use-cases/agent_customization.yml` - Original use case (legacy)

--- a/product/journeys/beads-plan-workflow.md
+++ b/product/journeys/beads-plan-workflow.md
@@ -1,0 +1,51 @@
+# Journey: Beads-Based Plan Workflow
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Use beads (DAG-based work units) to model and execute plans from drift with proper dependency tracking and parallelization
+
+## Context
+
+The current plan system uses a simple list of issues with basic dependency tracking. We need a more robust system that:
+- Models work as a Directed Acyclic Graph (DAG)
+- Tracks dependencies explicitly (what blocks what)
+- Supports parallel vs serial execution modes
+- Provides verification criteria for each work unit
+- Enables worker/agent assignment and progress tracking
+
+## Steps
+
+1. **Understand beads concept** → `specs/features/udd/beads/concept.feature`
+2. **Create bead-based plan** → `specs/features/udd/beads/create_plan.feature`
+3. **Track bead dependencies** → `specs/features/udd/beads/dependency_management.feature`
+4. **Execute beads with proper ordering** → `specs/features/udd/beads/execution.feature`
+5. **Verify bead completion** → `specs/features/udd/beads/verification.feature`
+
+## Success Criteria
+
+- Beads are created from drift issues with proper DAG structure
+- Dependencies are analyzed and modeled (test failures depend on scenario fixes)
+- Execution modes are respected (parallel, serial, exclusive)
+- Verification criteria can be checked automatically or manually
+- Workers can query for ready beads and mark them complete
+- Full traceability from drift issue → bead → completion
+
+## Related
+
+- Plan-process documentation is deferred to #50.
+- Implementation is deferred to #52.
+- Replaces/supersedes the simple plan backlog with richer DAG model
+
+## Phase
+
+Phase 3 - Agent Integration
+
+## Notes
+
+Beads provide a **work orchestration primitive** that can be used beyond just drift plans:
+- Feature implementation workflows
+- Refactoring campaigns
+- Multi-step migrations
+- Any work with dependencies and verification steps
+
+The name "bead" comes from the idea of stringing together work units like beads on a necklace - each one connected to the next, but also able to be viewed as individual units.

--- a/product/journeys/capture-ideas.md
+++ b/product/journeys/capture-ideas.md
@@ -1,0 +1,36 @@
+# Journey: Capture Ideas
+
+**Actor:** developer
+**Actor IDs:** developer
+
+**Goal:** Quickly capture feature ideas before they are forgotten
+
+**ID**: capture-ideas
+
+## Context
+
+Developers often have ideas while coding but lose them because
+capturing is too high-friction. This journey makes it effortless.
+
+## Steps
+
+1. **Trigger**: Developer has idea while working
+2. **Capture**: Developer records the idea without leaving the command line → `capture_ideas`
+3. **Confirmation**: CLI confirms idea captured with ID
+4. **Return**: Developer returns to coding immediately
+
+## Success Criteria
+
+- Capture takes < 5 seconds
+- No context switching required
+- Idea is traceable later
+
+## Use Cases
+
+- `capture_ideas` - Quick capture of raw ideas into the inbox
+
+## Trace
+
+- Persona: `developer` in `product/actors.md`
+- Use case: `capture_ideas` in `specs/use-cases/capture_ideas.yml`
+- Slice navigation: `specs/trace-slices/capture-ideas-inbox.md`

--- a/product/journeys/edge-case-hardening.md
+++ b/product/journeys/edge-case-hardening.md
@@ -1,0 +1,27 @@
+# Journey: Edge Case Hardening
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Ensure CLI handles edge cases gracefully
+
+## Context
+
+Edge cases like empty manifests, orphaned files, and sync failures need
+proper handling. This journey ensures robust error handling.
+
+## Steps
+
+1. System encounters edge case (empty manifest, orphan, etc.) → `specs/features/udd/cli/sync_edge_cases.feature`
+2. CLI detects the condition → `specs/features/udd/cli/status_edge_cases.feature`
+3. Appropriate error message or recovery action → `specs/features/udd/cli/scaffold_feature.feature`
+4. System remains stable → `specs/features/udd/cli/orphan_detection.feature`
+
+## Success Criteria
+
+- Edge-case CLI and agent scenarios are discoverable and linked
+- System handles edge cases without crashing
+- Recovery options are available where appropriate
+
+## Use Cases
+
+- `specs/use-cases/edge_case_hardening.yml` - Original use case (legacy)

--- a/product/journeys/enforce-code-style.md
+++ b/product/journeys/enforce-code-style.md
@@ -1,0 +1,27 @@
+# Journey: Enforce Code Style
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Ensure code styles are automatically applied and enforced
+
+## Context
+
+Consistent code style reduces cognitive load and makes code easier to review.
+This journey automates style enforcement.
+
+## Steps
+
+1. Developer writes code
+2. Pre-commit hooks run automatically → `specs/features/udd/dev-experience/commit_hooks.feature`
+3. Imports are sorted, code is formatted → `specs/features/udd/dev-experience/code_formatting.feature`
+4. Commit fails if style checks fail (can be overridden) → `specs/features/udd/dev-experience/code_formatting.feature`
+
+## Success Criteria
+
+- Imports are sorted automatically
+- Code formatting is consistent
+- Commits fail if style checks fail (unless overridden)
+
+## Use Cases
+
+- `specs/use-cases/enforce_code_style.yml` - Original use case (legacy)

--- a/product/journeys/enforce-quality-gates.md
+++ b/product/journeys/enforce-quality-gates.md
@@ -1,0 +1,37 @@
+# Journey: Enforce Quality Gates
+
+**Actor:** Team/Lead
+**Actor IDs:** team_lead
+**Goal:** Block commits with dirty tests
+
+## Context
+
+Teams struggle to maintain test quality over time. Tests accumulate with vague names, outdated assertions, and unclear ownership. Without enforcement, dirty tests slip through code review and degrade confidence in the test suite.
+
+Problems compound when:
+
+- Tests run green but do not actually verify behavior
+- Warnings accumulate until they become noise that everyone ignores
+- Engineers learn to work around quality checks instead of fixing root causes
+- CI passes while the test suite quietly rots
+
+Quality gates prevent this by catching problems at commit time, before they infect the codebase.
+
+## Steps
+
+1. Install hooks → `specs/features/udd/test-governance/hooks-installation.feature`
+   Set up pre-commit and pre-push hooks that validate test quality before allowing commits
+
+2. Pre-commit validation → `specs/features/udd/test-governance/pre-commit-validation.feature`
+   Run quick quality checks locally that block commits with dirty tests, warnings, or unlinked tests
+
+3. CI integration → `specs/features/udd/test-governance/ci-validation.feature`
+   Enforce quality gates in CI to catch anything that bypassed local hooks
+
+## Success Criteria
+
+- Dirty commits are blocked with clear error messages explaining what failed and why
+- Enforcement levels are configurable (strict, warn-only, disabled per check)
+- Local hooks catch 90%+ of quality issues before CI
+- CI gates never pass when quality checks fail
+- Error messages include specific remediation steps

--- a/product/journeys/fix-test-discovery.md
+++ b/product/journeys/fix-test-discovery.md
@@ -1,0 +1,27 @@
+# Journey: Fix Test Discovery
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Ensure tests are detected by VS Code extensions
+
+## Context
+
+Tests need to be visible in the IDE for effective development. This journey
+ensures Vitest extension properly discovers and displays all scenarios.
+
+## Steps
+
+1. Developer opens VS Code
+2. Vitest extension loads → `specs/features/udd/dev-experience/test_discovery/vscode_detection.feature`
+3. All scenarios appear in the test explorer → `specs/features/udd/dev-experience/test_discovery/editor_status.feature`
+4. Test status is visible in the editor
+
+## Success Criteria
+
+- Vitest extension shows all scenarios
+- Test status is visible in the editor
+- Tests can be run from the IDE
+
+## Use Cases
+
+- `specs/use-cases/fix_test_discovery.yml` - Original use case (legacy)

--- a/product/journeys/manage-test-lifecycle.md
+++ b/product/journeys/manage-test-lifecycle.md
@@ -1,0 +1,34 @@
+# Journey: Manage Test Lifecycle
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Review and approve tests with confidence
+
+## Context
+
+Developers face uncertainty when reviewing tests. Without clear standards or a defined process, reviews become inconsistent:
+
+- Unclear what criteria to apply during review
+- Inconsistent quality across tests from different authors
+- No record of which tests have been reviewed and approved
+- Difficulty trusting tests for critical decisions
+
+A structured review process with checklists, quality standards, and approval tracking gives developers confidence that tests are reliable and fit for purpose.
+
+## Steps
+
+1. Scan and link → `specs/features/udd/test-governance/test-scan.feature`
+   Identify all tests in the codebase and associate them with features they validate
+
+2. Review with checklist → `specs/features/udd/test-governance/test-review.feature`
+   Apply consistent criteria during review: coverage, readability, maintainability, naming
+
+3. Mark approval → `specs/features/udd/test-governance/test-approval.feature`
+   Record review outcome and approval status for audit trail
+
+## Success Criteria
+
+- Clear review process with documented checklist criteria
+- Consistent quality standards across all tests
+- Complete review history with approver and timestamp
+- Ability to identify unreviewed or outdated tests quickly

--- a/product/journeys/manage-wip.md
+++ b/product/journeys/manage-wip.md
@@ -1,0 +1,27 @@
+# Journey: Manage Work In Progress
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Avoid accumulating too many changes at once
+
+## Context
+
+Large changesets are harder to review and more likely to introduce bugs.
+This journey helps keep changes small and focused.
+
+## Steps
+
+1. Developer makes changes to code
+2. Agent monitors changeset size
+3. When threshold exceeded, agent warns developer → `specs/features/udd/agent/wip_enforcement/warn_on_large_changeset.feature`
+4. Developer is encouraged to commit current work → `specs/features/udd/agent/wip_enforcement/encourage_small_commits.feature`
+
+## Success Criteria
+
+- Agent warns when too many files are changed
+- Developer receives encouragement for small commits
+- Work-in-progress is visible and manageable
+
+## Use Cases
+
+- `specs/use-cases/manage_wip.yml` - Original use case (legacy)

--- a/product/journeys/monitor-test-health.md
+++ b/product/journeys/monitor-test-health.md
@@ -1,0 +1,35 @@
+# Journey: Monitor Test Health
+
+**Actor:** Team/Manager
+**Actor IDs:** team_manager
+**Goal:** Visibility into test governance status
+
+## Context
+
+Teams lack visibility into their test suite health. Without metrics, technical debt accumulates silently:
+
+- No way to know if test coverage is improving or degrading over time
+- Failing tests stay broken because there's no dashboard surfacing the problem
+- Setup issues (missing configs, broken dependencies) block developers but go unnoticed
+- Managers can't make data-driven decisions about testing investments
+
+Current status reports are manual, stale, or nonexistent. Teams discover problems only when critical builds fail or developers complain.
+
+## Steps
+
+1. Status integration → `specs/features/udd/test-governance/status-integration.feature`
+   Integrate with CI pipelines and test runners to automatically collect pass/fail status in real-time
+
+2. Health metrics → `specs/features/udd/test-governance/health-metrics.feature`
+   Calculate and track key health indicators: coverage trends, flakiness rates, suite execution time, debt accumulation
+
+3. Setup checks → `specs/features/udd/test-governance/setup-health-check.feature`
+   Validate that the test environment is properly configured and dependencies are satisfied
+
+## Success Criteria
+
+- At-a-glance dashboard showing current test suite health status
+- Historical trend tracking for coverage, reliability, and execution metrics
+- Actionable insights that guide improvement priorities ("flaky tests in auth module", "coverage dropped in API layer")
+- Alerts when health degrades beyond thresholds
+- Under 30 seconds for any team member to understand current state

--- a/product/journeys/orchestrated-iteration.md
+++ b/product/journeys/orchestrated-iteration.md
@@ -1,0 +1,29 @@
+# Journey: Orchestrated Iteration
+
+**Actor:** Developer, Orchestrator Agent, Worker Agent
+**Actor IDs:** developer, orchestrator_agent, worker_agent
+**Goal:** Enable continuous autonomous development with agent coordination
+
+## Context
+
+Complex projects benefit from orchestrated agent workflows. This journey
+enables an orchestrator to delegate work and monitor completion.
+
+## Steps
+
+1. Developer starts orchestrated session
+2. Orchestrator analyzes project status → `specs/features/opencode/orchestration/iterate_until_complete.feature`
+3. Orchestrator delegates tasks to worker agents → `specs/features/opencode/orchestration/stop_on_error.feature`
+4. Workers complete tasks and report back → `specs/features/opencode/tools/udd_status_tool.feature`
+5. Orchestrator continues until project complete → `specs/features/opencode/orchestration/configurable_iteration.feature`
+
+## Success Criteria
+
+- Orchestrator delegates work to workers and monitors completion
+- Orchestrator handles errors and preserves session state
+- Orchestrator uses structured status to make decisions
+- Developer can configure iteration limits and pause conditions
+
+## Use Cases
+
+- `specs/use-cases/orchestrated_iteration.yml` - Original use case (legacy)

--- a/product/journeys/phased-development.md
+++ b/product/journeys/phased-development.md
@@ -1,0 +1,27 @@
+# Journey: Phased Development
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Support incremental delivery with phased scenario tagging
+
+## Context
+
+Not all scenarios need to be implemented immediately. This journey allows
+deferring work to future phases while maintaining visibility.
+
+## Steps
+
+1. Developer identifies scenario for future phase → `specs/features/udd/cli/wip_support/wip_tag_support.feature`
+2. Tags scenario with `@phase:N` → `specs/features/udd/cli/wip_support/status_shows_wip.feature`
+3. Status command shows deferred items separately
+4. Agent understands deferred items are intentional → `specs/features/udd/agent/wip_support/agent_wip_awareness.feature`
+
+## Success Criteria
+
+- Scenarios can be tagged as @phase:N to defer to future phases
+- Status command shows deferred items separately from blocking failures
+- Agent understands deferred scenarios are intentionally deferred
+
+## Use Cases
+
+- `specs/use-cases/phased_development.yml` - Original use case (legacy)

--- a/product/journeys/prevent-regression.md
+++ b/product/journeys/prevent-regression.md
@@ -1,0 +1,30 @@
+# Journey: Prevent Regression
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Tests auto-marked when features change
+
+## Context
+
+When features change, it is hard to know which tests to re-run. Developers often either skip
+running tests they should run, or waste time running tests that are not affected by their
+changes. This leads to stale tests and false confidence. The system should automatically
+detect when feature files change and mark related tests as "dirty" so developers always know
+what needs attention.
+
+## Steps
+
+1. Developer changes a feature file → `specs/features/udd/test-governance/feature-change-detection.feature`
+2. System marks affected tests as dirty → `specs/features/udd/test-governance/dirty-marking.feature`
+3. Sync command reports dirty tests → `specs/features/udd/test-governance/sync-dirty-marking.feature`
+
+## Success Criteria
+
+- Feature changes are detected automatically
+- No manual tracking of which tests to run
+- Dirty reasons are clear and actionable
+- Developers can trust that dirty tests truly need attention
+
+## Use Cases
+
+- `specs/use-cases/prevent_regression.yml` - Original use case (legacy)

--- a/product/journeys/project-setup.md
+++ b/product/journeys/project-setup.md
@@ -1,0 +1,27 @@
+# Journey: Project Setup
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Initialize and configure the UDD project for development
+
+## Context
+
+Setting up a new UDD project should be simple and automated. This journey
+covers installation and initial configuration.
+
+## Steps
+
+1. Developer runs `npm install` to install dependencies
+2. Runs `npm link` to make CLI available globally
+3. Verifies installation with `udd --help` → `specs/features/udd/cli/setup.feature`
+4. Project is ready for development
+
+## Success Criteria
+
+- Dependencies are installed correctly
+- CLI tool is linked and available globally
+- Setup can be completed by agent or developer
+
+## Use Cases
+
+- `specs/use-cases/project_setup.yml` - Original use case (legacy)

--- a/product/journeys/recover-from-drift.md
+++ b/product/journeys/recover-from-drift.md
@@ -1,0 +1,322 @@
+# Journey: Recover from Drift
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Systematically restore UDD traceability through structured recovery workflow
+**Context**: Drift occurs when journeys, scenarios, and tests become inconsistent. This journey provides a practical, iterative recovery process that can be orchestrated by agents with user guidance.
+
+## Overview
+
+This journey implements a **structured recovery workflow** that:
+- Detects and catalogs all drift issues
+- Creates a prioritized backlog of recovery tasks
+- Processes tasks one-at-a-time with verification
+- Uses interactive questioning for ambiguous decisions
+- Maintains progress across sessions via checkpoints
+- Orchestrates parallel work where safe, serial where required
+
+## Steps
+
+### Phase 1: Discovery & Backlog Creation
+
+**1.1. Run comprehensive drift detection**
+- Execute `udd doctor --json` to get structured issue list
+- Categorize issues by severity (critical/warning/info)
+- Identify dependencies between issues
+- → `specs/features/udd/recovery/detect_and_categorize.feature`
+
+**1.2. Analyze issue dependencies**
+- Determine which issues block others
+- Identify safe parallel work streams
+- Flag issues requiring user input
+- → `specs/features/udd/recovery/analyze_dependencies.feature`
+
+**1.3. Create recovery backlog**
+- Generate `.udd/recovery-backlog.yml` with prioritized tasks
+- Each task includes: issue, severity, dependencies, estimated effort
+- Mark tasks as: auto-fixable, needs-user-input, blocked
+- → `specs/features/udd/recovery/create_recovery_backlog.feature`
+
+### Phase 2: Automated Resolution (Parallel Where Safe)
+
+**2.1. Execute safe auto-fixes**
+- Process all `autoFixable: true` issues without user input
+- Create missing scenario stubs
+- Create missing test files
+- Update stale timestamps (with verification)
+- → `specs/features/udd/recovery/execute_auto_fixes.feature`
+
+**2.2. Verify auto-fixes**
+- Run `udd doctor` to confirm fixes resolved issues
+- Mark completed tasks in backlog
+- Report any failed auto-fixes for manual handling
+- → `specs/features/udd/recovery/verify_auto_fixes.feature`
+
+### Phase 3: Interactive Resolution (One-at-a-Time)
+
+**3.1. Select next critical issue**
+- Read `.udd/recovery-backlog.yml`
+- Pick highest priority unresolved critical issue
+- Check dependencies are satisfied
+- → `specs/features/udd/recovery/select_next_issue.feature`
+
+**3.2. Analyze issue context**
+- Load related files (journey, scenario, test)
+- Check git history for recent changes
+- Identify decision points requiring user input
+- → `specs/features/udd/recovery/analyze_issue_context.feature`
+
+**3.3. Present decision to user**
+- Use question tool to present options
+- Show context and implications of each choice
+- Allow user to: resolve, skip, defer, or get more info
+- → `specs/features/udd/recovery/present_user_decision.feature`
+
+**3.4. Execute resolution**
+- Apply user's decision
+- Update files (journey links, scenarios, tests)
+- Create checkpoint for audit trail
+- → `specs/features/udd/recovery/execute_resolution.feature`
+
+**3.5. Verify and mark complete**
+- Run targeted validation
+- Update backlog status to "completed"
+- Log resolution for reporting
+- → `specs/features/udd/recovery/verify_and_complete.feature`
+
+**3.6. Loop or exit**
+- If more critical issues: return to 3.1
+- If only warnings remain: ask user if they want to continue
+- If user exits: save state for `--resume`
+- → `specs/features/udd/recovery/iteration_control.feature`
+
+### Phase 4: Sync & Final Validation
+
+**4.1. Run sync for all modified journeys**
+- Execute `udd sync` to regenerate artifacts
+- Handle any new drift introduced during recovery
+- → `specs/features/udd/recovery/sync_after_recovery.feature`
+
+**4.2. Final validation**
+- Run `udd doctor --strict`
+- Verify zero critical issues
+- Check all backlog tasks resolved
+- → `specs/features/udd/recovery/final_validation.feature`
+
+**4.3. Generate recovery report**
+- Summary: issues found, fixed, skipped
+- Time spent per phase
+- Recommendations for prevention
+- Archive backlog to `.udd/recovery-history/`
+- → `specs/features/udd/recovery/generate_report.feature`
+
+## Recovery Backlog Structure
+
+```yaml
+file: .udd/recovery-backlog.yml
+recovery_session:
+  id: "rec-2026-03-02-001"
+  started: "2026-03-02T17:00:00Z"
+  status: "in_progress" # in_progress | paused | completed
+
+issues:
+  - id: "crit-001"
+    type: "scenario_orphan"
+    severity: "critical"
+    file: "specs/auth/oauth.feature"
+    description: "Scenario has no journey link"
+    auto_fixable: false
+    needs_user_input: true
+    dependencies: []  # Can be done in parallel
+    status: "pending" # pending | in_progress | completed | skipped
+
+  - id: "warn-003"
+    type: "journey_stale"
+    severity: "warning"
+    file: "product/journeys/user-onboarding.md"
+    description: "Journey modified since last sync"
+    auto_fixable: true
+    needs_user_input: false
+    dependencies: []  # Safe to auto-fix
+    status: "pending"
+
+  - id: "crit-002"
+    type: "test_failing"
+    severity: "critical"
+    file: "tests/e2e/auth/login.e2e.test.ts"
+    description: "Test is failing"
+    auto_fixable: false
+    needs_user_input: true
+    dependencies: ["crit-001"]  # Must fix auth scenario first
+    status: "blocked"
+```
+
+## Agent Orchestration Pattern
+
+### Single Command Entry Point
+```bash
+udd doctor --fix --orchestrate
+```
+
+This command:
+1. **Creates backlog** if none exists
+2. **Checks for pending work** and resumes
+3. **Processes one task** to completion
+4. **Reports progress** and next steps
+5. **Exits cleanly** (no hanging prompts)
+
+### Iterative Workflow (No Repeated Prompting)
+
+**Agent Flow:**
+```
+while backlog.has_pending_issues():
+    # 1. Select issue
+    issue = backlog.next_critical_issue()
+
+    # 2. Check if auto-fixable
+    if issue.auto_fixable:
+        execute_auto_fix(issue)
+        verify_and_mark_complete(issue)
+        continue
+
+    # 3. Requires user input - ask ONE question
+    decision = question_tool.present_options(
+        context=load_context(issue),
+        options=generate_options(issue),
+        default="skip"
+    )
+
+    # 4. Execute and verify
+    execute_decision(decision, issue)
+    verify_and_mark_complete(issue)
+
+    # 5. Report status
+    print_progress_summary()
+
+    # 6. Continue automatically if more auto-fixable issues
+    #    Stop if next issue needs user input
+    if not backlog.next_auto_fixable():
+        print("Run 'udd doctor --fix --orchestrate' to continue")
+        break
+```
+
+### Question Tool Usage
+
+**When to use question tool:**
+- Scenario orphan: "Delete, link to journey, or mark as draft?"
+- Ambiguous reference: "Select correct path from candidates"
+- Test failure: "Fix test, mark pending, or skip?"
+- Phase mismatch: "Implement now, keep for future phase, or defer?"
+
+**Question format:**
+```javascript
+{
+  header: "Recovery Decision Required",
+  question: "Scenario 'specs/auth/oauth.feature' has no journey link. What should we do?",
+  options: [
+    {
+      label: "Link to journey",
+      description: "Select which journey this scenario belongs to"
+    },
+    {
+      label: "Delete scenario",
+      description: "Remove this orphaned scenario (irreversible)"
+    },
+    {
+      label: "Mark as draft",
+      description: "Keep but mark as work-in-progress"
+    },
+    {
+      label: "Skip for now",
+      description: "Leave unresolved and continue with other issues"
+    }
+  ]
+}
+```
+
+## Parallel vs Serial Work Identification
+
+### Safe for Parallel Processing
+- Creating missing scenario stubs (no dependencies)
+- Creating missing test files (no dependencies)
+- Fixing stale timestamps in different domains
+- Updating manifests
+
+### Must Be Serial
+- Orphan scenarios that might link to journeys being created
+- Test failures that depend on scenario fixes
+- Phase mismatches that affect multiple features
+- Checkpoint resolutions requiring user decisions
+
+### Dependency Graph
+The backlog creation phase builds a dependency graph:
+```yaml
+tasks:
+  - id: "create-scenarios"
+    parallel_safe: true
+    dependencies: []
+
+  - id: "link-orphans"
+    parallel_safe: false
+    dependencies: ["create-scenarios"]
+
+  - id: "sync-all"
+    parallel_safe: false
+    dependencies: ["link-orphans"]
+```
+
+## Resumption Strategy
+
+### Session Persistence
+```yaml
+file: .udd/recovery-session.yml
+session:
+  id: "rec-2026-03-02-001"
+  created: "2026-03-02T17:00:00Z"
+  last_activity: "2026-03-02T17:30:00Z"
+  current_phase: "interactive_resolution"
+  current_issue: "crit-003"
+  completed_count: 5
+  total_count: 20
+
+backlog: # Reference to recovery-backlog.yml
+  file: ".udd/recovery-backlog.yml"
+
+checkpoints:
+  - issue_id: "crit-001"
+    decision: "link_to_journey"
+    selected_journey: "user-authentication"
+    timestamp: "2026-03-02T17:15:00Z"
+```
+
+### Resume Command
+```bash
+udd doctor --fix --orchestrate --resume
+
+Alternative command:
+udd recovery resume
+```
+
+## Success Criteria
+
+- [ ] All critical issues resolved or consciously skipped
+- [ ] Recovery backlog shows 100% completion (or documented skips)
+- [ ] `udd doctor --strict` passes with exit code 0
+- [ ] No orphaned scenarios without decisions
+- [ ] All checkpoints documented in `.udd/checkpoints.yml`
+- [ ] Recovery report generated and archived
+- [ ] Agent can run `udd doctor --fix --orchestrate` without getting stuck
+
+## Prevention Integration
+
+Link to ongoing maintenance:
+- `validate-specs` journey - catch drift early
+- `monitor-test-health` journey - ongoing health visibility
+- `traceability-compliance` journey - periodic audits
+
+## Related
+
+- Detailed recovery process documentation is deferred to #50.
+- `traceability-compliance` journey - Ongoing compliance
+- `validate-phase-consistency` journey - Phase drift detection
+- `prevent-regression` journey - Sync and dirty marking

--- a/product/journeys/run-tests.md
+++ b/product/journeys/run-tests.md
@@ -1,0 +1,27 @@
+# Journey: Run Tests
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Execute tests and track implementation progress
+
+## Context
+
+Tests verify that the system works as specified. Running tests should be
+easy and provide clear feedback on what's passing and failing.
+
+## Steps
+
+1. Developer implements a feature → `specs/features/udd/cli/run_tests.feature`
+2. Runs `npm test` to execute all tests
+3. Views results to see pass/fail status → `specs/features/udd/cli/check_status.feature`
+4. Checks `udd status` for project-wide progress
+
+## Success Criteria
+
+- Tests can be executed via CLI
+- Project status is visible and up-to-date
+- Failures are clearly reported with context
+
+## Use Cases
+
+- `specs/use-cases/run_tests.yml` - Original use case (legacy)

--- a/product/journeys/traceability-compliance.md
+++ b/product/journeys/traceability-compliance.md
@@ -1,0 +1,53 @@
+# Journey: Ensure UDD Traceability Compliance
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Verify that product intent, roadmap use cases, scenarios, tests, and
+implementation requirements stay connected as UDD evolves.
+
+## Context
+
+UDD should dogfood its own traceability model. This journey is future product
+intent for issue #51; this foundation PR records the intent and makes the
+current roadmap explicit without importing the validation CLI or test-governance
+implementation.
+
+The roadmap is the current classification source:
+
+- Active or delivered journeys are represented by `specs/roadmap.yml`
+  `phases[].use_cases[]` entries.
+- Deferred use cases that already belong to a capability are represented by
+  `phases[].use_cases[]` entries with `status: future` and a `follow_up` issue.
+- Deferred journeys that do not yet belong to an executable capability slice are
+  represented by `specs/roadmap.yml` `backlog_journeys[]` entries with a
+  `follow_up` issue.
+- Scenario ids belong in `scenarios` or `future_scenarios`.
+- Feature paths belong in `scenario_paths` or `future_scenario_paths`.
+
+## Steps
+
+1. Read `specs/roadmap.yml` to identify current and deferred product journeys.
+2. Validate that every active or delivered use case links to scenario ids and
+   scenario paths.
+3. Validate that every deferred use case or backlog journey has an exact
+   `follow_up` issue.
+4. Validate requirement and component artifacts against
+   `specs/traceability-contract.yml`.
+5. Report gaps as actionable source-of-truth drift instead of silently creating
+   generated state.
+
+## Success Criteria
+
+- Every current product journey is represented by a roadmap use case or a
+  `backlog_journeys` entry.
+- Every current roadmap use case has canonical scenario ids, with feature paths
+  stored separately when path lookup is needed.
+- Every deferred use case and backlog journey references the issue that owns
+  its executable slice.
+- Strict traceability validation is implemented and passing in the #51 slice.
+
+## Related
+
+- `specs/roadmap.yml` - Current journey/use-case classification
+- `specs/traceability-contract.yml` - Traceability artifact contract
+- #51 - Phase and traceability CLI foundation

--- a/product/journeys/track-test-quality.md
+++ b/product/journeys/track-test-quality.md
@@ -1,0 +1,32 @@
+# Journey: Track Test Quality
+
+**Actor:** Developer
+**Actor IDs:** developer
+**Goal:** Know which tests need review and why
+
+## Context
+
+Developers waste time figuring out which tests matter. Tests accumulate without clear ownership, leading to:
+
+- Wasted time digging through unrelated tests when a feature changes
+- Missed tests that should have been updated alongside code changes
+- Lost confidence in the test suite as coverage gaps grow unnoticed
+
+Without visibility into test status, teams either over-test (slowing development) or under-test (risking regressions).
+
+## Steps
+
+1. Link tests to features → `specs/features/udd/test-governance/test-linkage.feature`
+   Associate tests with the features they validate so changes to a feature automatically surface relevant tests
+
+2. Check test status → `specs/features/udd/test-governance/test-status.feature`
+   See at a glance which tests are passing, failing, outdated, or need review
+
+3. Mark tests clean → `specs/features/udd/test-governance/test-review.feature`
+   Record when tests have been reviewed and are trusted for the current feature version
+
+## Success Criteria
+
+- Clear status visibility for every test (linked to features, last review date, current status)
+- Under 10 seconds to understand the quality state of any test or feature
+- Automatic linkage between code changes and affected tests

--- a/product/journeys/validate-phase-consistency.md
+++ b/product/journeys/validate-phase-consistency.md
@@ -1,0 +1,45 @@
+# Journey: Validate Phase Consistency
+
+**Actor:** Developer, Team Lead
+**Actor IDs:** developer, team_lead
+**Goal:** Keep vision-derived roadmap state aligned with executable specs (@phase tags)
+
+## Context
+
+UDD uses `specs/VISION.md` as the stable statement of project purpose and
+`specs/roadmap.yml` as the derived, mutable planning state. Feature files use
+@phase:N tags to indicate which phase they belong to. These can drift:
+
+- VISION says agent integrations should be reusable across tools
+- `specs/roadmap.yml` says `current_phase: opencode-integration` (legacy Phase 3 id, now named Agent Integration)
+- Feature files have @phase:4 tags (Agent Intelligence phase)
+- No automated validation catches this mismatch
+
+This leads to confusion about what work is in scope, whether backlog items still
+serve the vision, and whether teams are prematurely implementing future-phase
+features.
+
+## Steps
+
+1. Read `specs/VISION.md` for stable project goals → `specs/features/udd/compliance/phase-consistency-validation.feature`
+2. Parse `specs/roadmap.yml` to extract current phase and phase definitions
+3. Scan all feature files for @phase:N tags → `tests/e2e/udd/compliance/phase_consistency_validation.e2e.test.ts`
+4. Compare phase tags against current_phase
+5. Report mismatches and suggest corrections
+6. Validate phase numbering is sequential (no gaps)
+
+## Success Criteria
+
+- Detect when feature @phase tags exceed roadmap current phase
+- Keep roadmap/current-phase decisions grounded in the stable vision
+- Warn when roadmap says Phase 3 but features are tagged Phase 4
+- Suggest which features should be in current phase based on journey links
+- Validate phase numbers are sequential without gaps
+- Validation runs as part of `udd validate --strict`
+
+## Related
+
+- `specs/VISION.md` - Stable project vision and backlog foundation
+- `specs/roadmap.yml` - Derived phase definitions and current phase
+- `specs/features/opencode/*` - Features with @phase:4 tags
+- `docs/sysml-informed-discovery.md` - Traceability principles

--- a/product/journeys/validate-specs.md
+++ b/product/journeys/validate-specs.md
@@ -1,0 +1,27 @@
+# Journey: Validate Specs
+
+**Actor:** Developer, Agent
+**Actor IDs:** developer, agent
+**Goal:** Ensure specs follow the defined structure and schemas
+
+## Context
+
+Specs need to be valid to ensure traceability and proper test generation.
+This journey provides validation tools.
+
+## Steps
+
+1. Developer writes or updates specs → `specs/features/udd/cli/lint_valid_specs.feature`
+2. Runs `udd lint` to validate structure → `specs/features/udd/cli/lint_invalid_specs.feature`
+3. Gets feedback on any issues
+4. Fixes issues until validation passes
+
+## Success Criteria
+
+- Valid specs pass linting without errors
+- Invalid specs report clear, actionable errors
+- Validation is fast (< 1 second)
+
+## Use Cases
+
+- `specs/use-cases/validate_specs.yml` - Original use case (legacy)

--- a/specs/VISION.md
+++ b/specs/VISION.md
@@ -2,92 +2,76 @@
 id: "udd_tool"
 name: "User Driven Development Tool"
 version: "0.0.1"
-current_phase: 3
-phases:
-  1: "Core CLI & Validation"
-  2: "Research & Tech Specs"
-  3: "OpenCode Integration"
-  4: "Agent Intelligence"
-  5: "Advanced Workflows"
 goals:
-  - "Make user-facing scenarios the single source of truth"
-  - "Use SysML principles to create better scenarios (not add layers)"
-  - "Let agents assist with requirements discovery and analysis"
-  - "Keep everything simple, discoverable, and deterministic"
-  - "Enforce guardrails against spec/test tampering"
-  - "Enable autonomous iteration via OpenCode integration"
+  - "Make stakeholder journeys the durable source of product intent."
+  - "Derive testable BDD scenarios from user-visible outcomes."
+  - "Verify implementations through independent tests that exercise behavior from stakeholder perspectives."
+  - "Preserve traceability from persona and journey through use case, scenario, test, component, and requirement."
+  - "Give human and AI contributors a concise, deterministic project state model for safe iteration."
 use_cases:
   - "validate_specs"
   - "run_tests"
   - "orchestrated_iteration"
+  - "track_test_quality"
+  - "prevent_regression"
+  - "manage_test_lifecycle"
+  - "validate_phase_consistency"
+success_metrics:
+  - "A project can be understood and rebuilt from product intent, scenarios, and traceable requirements without relying on hidden implementation memory."
+  - "Current-phase stub tests are blocked before they create false confidence."
+  - "Agent integrations reuse shared UDD utilities instead of duplicating integration-specific workflows."
+  - "Vision remains stable while roadmap state changes in specs/roadmap.yml."
 ---
 
 # Vision
 
-The UDD tool provides a CLI to manage the lifecycle of features in a User Driven Development process. It ensures that specs are the source of truth and that features are only considered done when their E2E tests pass.
+UDD exists to make software rebuildable from stakeholder intent.
 
-## Branching Strategy
+The durable product record is the chain from persona and journey through use
+case, scenario, independent verification, component responsibility, and
+implementation requirement. A contributor should be able to inspect that chain
+and understand what the system must do, why it matters, how it is verified, and
+which implementation surface is responsible.
 
-The repository default branch is currently `master` (`origin/HEAD -> origin/master` as verified on 2026-05-29). Treat `master` as the stable branch and PR target unless a future repo-wide branch rename explicitly changes the GitHub default branch.
+UDD is not a project tracker, test runner, or code generator. It is the control
+layer that keeps intent, acceptance criteria, independent tests, and
+implementation work aligned.
 
-```
-master                            # Stable, all tests pass
-  └── phase/<n>                   # Active development phase
-        ├── feat/<area>/<feature> # One branch per feature
-        └── research/<id>         # Research investigations
-```
+## Future State
 
-### Branch Rules
+In the target state, a project using UDD can be rebuilt from its source specs:
 
-| Branch | Purpose | Merges To |
-|--------|---------|-----------|
-| `master` | Stable baseline | - |
-| `phase/<n>` | Phase development | `master` when phase complete |
-| `feat/<area>/<feature>` | Feature implementation | `phase/<n>` |
-| `research/<id>` | Investigation (docs only) | `phase/<n>` |
+1. Stakeholders define personas, journeys, outcomes, and constraints.
+2. Use cases map each journey outcome to executable behavior.
+3. BDD scenarios describe acceptance from the stakeholder perspective.
+4. Independent E2E tests verify behavior without depending on implementation
+   internals.
+5. Components and requirements document how the system satisfies the verified
+   behavior.
+6. Agent integrations use the same project-state and traceability utilities, so
+   Codex, OpenCode, and future integrations behave consistently.
 
-### Workflow
+## Backlog Foundation
 
-1. **Start phase**: `git checkout -b phase/1 master`
-2. **Start feature**: `git checkout -b feat/cli/status phase/1`
-3. **Complete feature**: PR to `phase/1`, squash merge
-4. **Complete phase**: PR to `master`, merge when objectives met
+When no backlog is available, new backlog items should be derived from this
+vision first. Agents should use this document to understand the project goal,
+then derive structured roadmap items, use cases, scenarios, tests, components,
+and requirements that keep work aligned with the long-term direction.
 
-### Research Branches
+Derived backlog items should point back to the relevant vision goal or success
+metric, then become concrete in `specs/roadmap.yml`, `product/journeys/`,
+`specs/use-cases/`, and `specs/features/`.
 
-- Only commit `specs/research/<id>/README.md`
-- Prototype code stays local (never committed)
-- Merge learnings document, delete branch
+## State Boundaries
 
-## Phase Objectives
+This file intentionally does not declare the current phase, active branch, or
+progress status. Time- and progress-dependent planning belongs in
+`specs/roadmap.yml`, generated status output, and goal documents under
+`goals/`.
 
-### Phase 1: Core CLI & Validation ✅
-- Basic scaffolding commands
-- Spec validation (lint)
-- Status reporting
+The repository default branch was verified as `master` on 2026-05-29. Branch
+renames must update GitHub repository settings and branch-sensitive goal or
+workflow documents together; this vision file should not carry a separate
+branching strategy.
 
-### Phase 2: Research & Tech Specs
-- Research workflow and commands
-- Tech spec scaffolding
-- Unit test tracing
-
-### Phase 3: OpenCode Integration
-- Custom tools for structured status (`udd-status`, `udd-next`)
-- Orchestrator plugin for autonomous iteration
-- JSON output mode for machine consumption
-- Configurable iteration limits and pause conditions
-
-### Phase 4: Agent Intelligence
-- Copilot integration improvements
-- Autonomous maintenance
-- Smart suggestions
-
-### Phase 5: Advanced Workflows
-- Spec change tracking
-- Migration tools
-- Team collaboration features
-
-## References
-
-*   [Custom Agent File Structure](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure)
-*   [Prompt Files](https://code.visualstudio.com/docs/copilot/customization/prompt-files)
+`specs/VISION.md` should change only when the long-term product vision changes.

--- a/specs/components/cli-inbox-command.yml
+++ b/specs/components/cli-inbox-command.yml
@@ -1,0 +1,24 @@
+id: cli-inbox-command
+name: CLI Inbox Command
+type: cli-command
+owner: udd-cli
+source:
+  - src/commands/inbox.ts
+public_interfaces:
+  - command: udd inbox add <title>
+    options:
+      - --description <description>
+responsibilities:
+  - Accept an idea title and optional description from the command line.
+  - Append a new inbox item to the current project's inbox store.
+  - Print a confirmation that identifies the captured idea title.
+supported_use_cases:
+  - capture_ideas
+supported_scenarios:
+  - udd/cli/inbox/add_item_via_cli
+requirements:
+  - persist_inbox_item
+tests:
+  - tests/e2e/udd/cli/inbox/add_item_via_cli.e2e.test.ts
+notes:
+  - "This component owns the command boundary only; scenario acceptance text remains in the feature file."

--- a/specs/journey-map.example.yml
+++ b/specs/journey-map.example.yml
@@ -1,0 +1,65 @@
+# Journey Structured Map Example
+# Conforming example demonstrating valid journey-to-use-case mapping.
+
+journey_map:
+  id: new-user-onboarding
+  title: New User Quick Start
+  actor: team-member
+  goal: Sign up and start using the app
+
+  trigger_conditions:
+    - type: event
+      description: User visits app for first time
+
+  steps:
+    - sequence: 1
+      name: User signs up
+      use_case_ref: user-signup
+      entry_conditions:
+        - type: state
+          description: User is unauthenticated
+      exit_conditions:
+        - type: event
+          description: Account created and verified
+      success_metrics:
+        - id: signup-completion
+          description: User completes signup flow
+          target: ">80%"
+          metric_reference: analytics.signup_completed
+
+    - sequence: 2
+      name: User creates first item
+      use_case_ref: create-first-item
+      entry_conditions:
+        - type: state
+          description: User is authenticated with verified account
+      exit_conditions:
+        - type: event
+          description: Item appears in inbox
+      success_metrics:
+        - id: first-item-creation
+          description: User creates first item within 5 minutes
+          target: ">50%"
+          metric_reference: analytics.first_item_created
+
+    - sequence: 3
+      name: User organizes items
+      use_case_ref: organize-items
+      entry_conditions:
+        - type: state
+          description: User has at least one item in inbox
+      exit_conditions:
+        - type: event
+          description: Items are tagged or prioritized
+      success_metrics:
+        - id: organization-rate
+          description: Users who organize at least one item
+          target: ">30%"
+
+  success_metrics:
+    - id: onboarding-completion
+      description: Users who complete onboarding within 10 minutes
+      target: ">60%"
+      metric_reference: analytics.onboarding_completed
+
+validation_rules: []

--- a/specs/journey-map.schema.yml
+++ b/specs/journey-map.schema.yml
@@ -1,0 +1,304 @@
+# Journey Structured Map Schema
+# Defines a traceable mapping between journey steps and use cases.
+# Purpose: Enable forward/reverse traceability queries from journey to use_case layer.
+# Alignment: Implements trace query "journey_to_use_case" from specs/traceability-contract.yml
+
+# ============================================================================
+# SCHEMA OVERVIEW
+# ============================================================================
+# This schema captures structural journey-to-use-case trace links. Broader
+# journey narrative documentation is deferred to #50.
+
+# Key design principles:
+# - Steps must reference use_case.id (required) to maintain forward trace integrity
+# - Each step has explicit sequence for ordered traversal
+# - Conditions (trigger/entry/exit) are optional but enable conditional journeys
+# - Success metrics are per-step to enable granular measurement
+# - Validation rules documented for missing/invalid use_case references
+
+# ============================================================================
+# ROOT STRUCTURE
+# ============================================================================
+
+$schema: "http://json-schema.org/draft-07/schema#"
+title: Journey Structured Map
+description: Traceable mapping between journey steps and use cases
+
+type: object
+properties:
+  journey_map:
+    type: object
+    description: Container for journey-to-use-case mapping
+    properties:
+      id:
+        type: string
+        description: Unique journey identifier (kebab-case slug)
+        pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        example: new-user-onboarding
+
+      title:
+        type: string
+        description: Human-readable journey title
+        example: New User Onboarding
+
+      actor:
+        type: string
+        description: Reference to persona id who performs this journey
+        pattern: "^[a-z0-9]+(_[a-z0-9]+)*$"
+        example: team_member
+
+      goal:
+        type: string
+        description: Outcome the user wants to achieve
+        example: Sign up and start using the app
+
+      trigger_conditions:
+        type: array
+        description: Conditions that initiate this journey
+        items:
+          $ref: "#/definitions/condition"
+
+      steps:
+        type: array
+        description: Ordered sequence of journey steps with use_case references
+        items:
+          $ref: "#/definitions/step"
+        minItems: 1
+
+      success_metrics:
+        type: array
+        description: Journey-level success measurements
+        items:
+          $ref: "#/definitions/success_metric"
+
+    required:
+      - id
+      - actor
+      - goal
+      - steps
+    additionalProperties: false
+
+  validation_rules:
+    type: array
+    description: Rules for validating journey map integrity and traceability
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          example: UC001
+        name:
+          type: string
+          example: use_case_reference_required
+        description:
+          type: string
+        severity:
+          type: string
+          enum: [error, warning]
+        check:
+          type: string
+        rationale:
+          type: string
+
+definitions:
+
+  journey_id:
+    type: string
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    description: Unique journey identifier in kebab-case
+    example: new-user-onboarding
+
+  persona_id:
+    type: string
+    pattern: "^[a-z0-9]+(_[a-z0-9]+)*$"
+    description: Reference to persona.id from product/actors.md (snake_case canonical)
+    example: team_member
+
+  use_case_id:
+    type: string
+    # UDD use case ids match specs/use-cases/*.yml ids and use snake_case.
+    # Journey ids remain kebab-case because they map to product/journeys/*.md slugs.
+    pattern: "^[a-z0-9]+(_[a-z0-9]+)*$"
+    description: Reference to use_case.id from specs/use-cases/ (snake_case canonical)
+    example: capture_ideas
+
+  condition:
+    type: object
+    description: A condition that triggers or gates journey progression
+    properties:
+      type:
+        type: string
+        enum: [event, state, time, user_action]
+        description: Category of condition
+      description:
+        type: string
+        description: Human-readable condition description
+      expression:
+        type: string
+        description: Optional machine-readable expression
+    required:
+      - type
+      - description
+
+  step:
+    type: object
+    description: A single step in the journey, referencing a use_case
+    properties:
+      sequence:
+        type: integer
+        minimum: 1
+        description: Explicit sequence number for ordering
+        example: 1
+
+      name:
+        type: string
+        description: Brief step name (narrative summary, not Gherkin)
+        example: User signs up
+
+      use_case_ref:
+        # Reference the shared use_case_id definition for canonical UDD use case ids.
+        $ref: "#/definitions/use_case_id"
+
+      entry_conditions:
+        type: array
+        description: Conditions required to enter this step
+        items:
+          $ref: "#/definitions/condition"
+
+      exit_conditions:
+        type: array
+        description: Conditions that signal step completion
+        items:
+          $ref: "#/definitions/condition"
+
+      success_metrics:
+        type: array
+        description: Step-level success measurements
+        items:
+          $ref: "#/definitions/success_metric"
+
+      notes:
+        type: string
+        description: Optional notes about step execution
+
+    required:
+      - sequence
+      - name
+      - use_case_ref
+
+  success_metric:
+    type: object
+    description: A measurable outcome indicator
+    properties:
+      id:
+        type: string
+        pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        description: Metric identifier
+        example: signup-completion-rate
+
+      description:
+        type: string
+        description: What success looks like
+        example: User completes signup within 5 minutes
+
+      target:
+        type: string
+        description: Target value or threshold
+        example: ">80%"
+
+      metric_reference:
+        type: string
+        description: Optional reference to analytics or monitoring metric
+        example: analytics.signup_confirmed
+
+    required:
+      - id
+      - description
+
+# ============================================================================
+# VALIDATION RULES
+# ============================================================================
+# These rules can be enforced via udd lint or CI checks.
+# Missing use_case_ref is an ERROR (blocks forward trace).
+
+validation_rules:
+  - id: UC001
+    name: use_case_reference_required
+    description: Each step MUST reference a valid use_case.id
+    severity: error
+    check: |
+      For each step in journey_map.steps:
+      - use_case_ref MUST be present and non-empty
+      - use_case_ref MUST match pattern: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
+      - use_case_ref SHOULD correspond to an existing use_case in specs/use-cases/
+    rationale: |
+      Without use_case_ref, forward trace journey_to_use_case cannot resolve.
+
+  - id: UC002
+    name: steps_ordered_sequentially
+    description: Steps must have explicit sequence numbers starting from 1
+    severity: error
+    check: |
+      - Each step MUST have a sequence number (integer >= 1)
+      - Sequence numbers SHOULD be consecutive (1, 2, 3...)
+      - Gaps in sequence indicate missing steps
+
+  - id: UC003
+    name: persona_reference_valid
+    description: Journey actor must reference valid persona.id
+    severity: error
+    check: |
+      - actor field MUST be non-empty string
+      - actor SHOULD correspond to existing persona in product/actors.md
+
+  - id: UC004
+    name: no_duplicate_scenario_steps
+    description: Journey map must NOT duplicate Gherkin scenario step text
+    severity: warning
+    check: |
+      - Step name/description should be brief narrative summary
+      - Do NOT include Given/When/Then Gherkin text here
+      - Actual scenario steps remain in .feature files only
+    rationale: |
+      Scenario text belongs in .feature files (per traceability-contract).
+      Journey map references use_case.id which in turn references scenarios.
+      This separation maintains single source of truth for behavior.
+
+  - id: UC005
+    name: condition_format_valid
+    description: Trigger/entry/exit conditions must have valid type and description
+    severity: warning
+    check: |
+      - Each condition MUST have type: event|state|time|user_action
+      - Each condition MUST have description (non-empty string)
+
+  - id: UC006
+    name: metric_format_valid
+    description: Success metrics must have id, description, and target
+    severity: warning
+    check: |
+      - Each metric MUST have id (kebab-case)
+      - Each metric MUST have description (non-empty)
+      - Each metric SHOULD have target value
+
+# ============================================================================
+# SCHEMA NOTES
+# ============================================================================
+notes: |
+  1. This schema defines the STRUCTURED MAP for journey-to-use-case linkage.
+     For the EXPERIENCE timeline with user-observable details, see
+     the architecture/process documentation tracked by #50
+
+  2. Scenario step text remains in .feature files only. Journey maps reference
+     use_case.id which provides the bridge to scenarios. This maintains single
+     source of truth for behavior specification.
+
+  3. Validation rules UC001-UC006 can be enforced via udd lint or CI checks.
+     Missing use_case_ref is an ERROR (blocks forward trace).
+     Invalid persona reference is an ERROR (breaks reverse trace).
+
+  4. The journey_map.steps array order defines traversal order. Use explicit
+     sequence numbers to avoid ambiguity when steps are reordered.
+
+  5. For trace query "journey_to_use_case" (specs/traceability-contract.yml),
+     the journey_map provides: journey.id -> steps[].use_case_ref -> use_case.id

--- a/specs/requirements/persist_inbox_item.yml
+++ b/specs/requirements/persist_inbox_item.yml
@@ -1,0 +1,21 @@
+id: persist_inbox_item
+key: persist_inbox_item
+type: functional
+feature: udd/cli/inbox
+use_cases:
+  - capture_ideas
+scenarios:
+  - add_item_via_cli
+scenario_paths:
+  - udd/cli/inbox/add_item_via_cli
+components:
+  - cli-inbox-command
+tests:
+  - tests/e2e/udd/cli/inbox/add_item_via_cli.e2e.test.ts
+description: "The inbox add command records a titled idea with its optional description in the active project's inbox and confirms the captured title to the user."
+acceptance_criteria:
+  - "A titled idea submitted through the command is present in the project inbox after the command completes."
+  - "The optional description submitted with the command is stored with the same inbox item."
+  - "The command prints a success confirmation that includes the captured title."
+notes:
+  - "The scenario remains the acceptance source; this requirement records implementation responsibility and verification links without copying Gherkin steps."

--- a/specs/roadmap.yml
+++ b/specs/roadmap.yml
@@ -1,0 +1,380 @@
+# UDD Project Roadmap
+# Single source of truth for phase assignments and capability evolution
+
+# Current active phase
+current_phase: opencode-integration
+phases:
+  - id: core-cli
+    name: Core CLI & Validation
+    number: 1
+    status: completed
+    description: Basic scaffolding, validation, status reporting
+    use_cases:
+      - id: validate_specs
+        capability: core-workflow
+        increment: v1-basic
+        scenarios:
+          - lint_valid_specs
+          - lint_invalid_specs
+          - discover_feature
+          - validate_completeness
+        scenario_paths:
+          - udd/cli/lint_valid_specs
+          - udd/cli/lint_invalid_specs
+          - udd/cli/validation/discover_feature
+          - udd/cli/validation/validate_completeness
+      - id: run_tests
+        capability: core-workflow
+        increment: v1-basic
+        scenarios:
+          - run_tests
+          - check_status
+        scenario_paths:
+          - udd/cli/run_tests
+          - udd/cli/check_status
+      - id: project_setup
+        capability: core-workflow
+        increment: v1-basic
+        scenarios:
+          - setup
+        scenario_paths:
+          - udd/cli/setup
+      - id: edge_case_hardening
+        capability: core-workflow
+        increment: v1-hardening
+        scenarios:
+          - sync_edge_cases
+          - status_edge_cases
+          - scaffold_feature
+          - orphan_detection
+          - manifest_recovery
+          - init_edge_cases
+          - query_commands
+        scenario_paths:
+          - udd/cli/sync_edge_cases
+          - udd/cli/status_edge_cases
+          - udd/cli/scaffold_feature
+          - udd/cli/orphan_detection
+          - udd/cli/manifest_recovery
+          - udd/cli/init_edge_cases
+          - udd/agent/query_commands
+  - id: research-specs
+    name: Research & Tech Specs
+    number: 2
+    status: completed
+    description: Research workflow, tech spec scaffolding
+    use_cases:
+      - id: phased_development
+        capability: core-workflow
+        increment: v2-phased
+        scenarios:
+          - wip_tag_support
+          - status_shows_wip
+          - agent_wip_awareness
+        scenario_paths:
+          - udd/cli/wip_support/wip_tag_support
+          - udd/cli/wip_support/status_shows_wip
+          - udd/agent/wip_support/agent_wip_awareness
+      - id: manage_wip
+        capability: agent-workflow
+        increment: v1-basic
+        scenarios:
+          - warn_on_large_changeset
+          - encourage_small_commits
+        scenario_paths:
+          - udd/agent/wip_enforcement/warn_on_large_changeset
+          - udd/agent/wip_enforcement/encourage_small_commits
+      - id: enforce_code_style
+        capability: developer-experience
+        increment: v1-basic
+        scenarios:
+          - sort_imports
+          - code_formatting
+          - commit_hooks
+        scenario_paths:
+          - udd/dev-experience/sort_imports
+          - udd/dev-experience/code_formatting
+          - udd/dev-experience/commit_hooks
+      - id: fix_test_discovery
+        capability: developer-experience
+        increment: v1-basic
+        scenarios:
+          - vscode_detection
+          - editor_status
+        scenario_paths:
+          - udd/dev-experience/test_discovery/vscode_detection
+          - udd/dev-experience/test_discovery/editor_status
+  - id: opencode-integration
+    name: Agent Integration
+    number: 3
+    status: active
+    description: Shared integration contracts, adapter tools, orchestrator plugin, JSON output
+    use_cases:
+      - id: orchestrated_iteration
+        capability: autonomous-development
+        increment: v1-basic
+        scenarios:
+          - iterate_until_complete
+          - stop_on_error
+          - configurable_iteration
+          - udd_status_tool
+        scenario_paths:
+          - opencode/orchestration/iterate_until_complete
+          - opencode/orchestration/stop_on_error
+          - opencode/orchestration/configurable_iteration
+          - opencode/tools/udd_status_tool
+      - id: agent_customization
+        capability: autonomous-development
+        increment: v1-basic
+        scenarios:
+          - status_prompt
+          - guide_user
+          - codex_hooks
+        future_scenarios:
+          follow_up: "#54"
+          scenarios:
+            - status_deep
+            - next_recommendation
+            - issues_list
+          scenario_paths:
+            - opencode/tools/status_deep
+            - opencode/tools/next_recommendation
+            - opencode/tools/issues_list
+        scenario_paths:
+          - udd/agent/status_prompt
+          - udd/agent/guide_user
+          - udd/cli/codex_hooks
+      - id: capture_ideas
+        capability: idea-management
+        increment: v1-basic
+        scenarios:
+          - add_item_via_cli
+        scenario_paths:
+          - udd/cli/inbox/add_item_via_cli
+      - id: track_test_quality
+        capability: test-governance
+        increment: v1-basic
+        status: future
+        follow_up: "#55"
+        future_scenarios:
+          - health-metrics
+          - test-scan
+          - test-status
+        future_scenario_paths:
+          - udd/test-governance/health-metrics
+          - udd/test-governance/test-scan
+          - udd/test-governance/test-status
+      - id: prevent_regression
+        capability: test-governance
+        increment: v1-basic
+        status: future
+        follow_up: "#55"
+        future_scenarios:
+          - feature-change-detection
+          - dirty-marking
+          - sync-dirty-marking
+        future_scenario_paths:
+          - udd/test-governance/feature-change-detection
+          - udd/test-governance/dirty-marking
+          - udd/test-governance/sync-dirty-marking
+      - id: manage_test_lifecycle
+        capability: test-governance
+        increment: v1-basic
+        status: future
+        follow_up: "#55"
+        future_scenarios:
+          - test-review
+          - hooks-installation
+          - pre-commit-validation
+        future_scenario_paths:
+          - udd/test-governance/test-review
+          - udd/test-governance/hooks-installation
+          - udd/test-governance/pre-commit-validation
+      - id: enforce_quality_gates
+        capability: test-governance
+        increment: v1-basic
+        status: future
+        follow_up: "#55"
+        future_scenarios:
+          - ci-validation
+          - test-approval
+          - status-integration
+        future_scenario_paths:
+          - udd/test-governance/ci-validation
+          - udd/test-governance/test-approval
+          - udd/test-governance/status-integration
+      - id: monitor_test_health
+        capability: test-governance
+        increment: v1-basic
+        status: future
+        follow_up: "#55"
+        future_scenarios:
+          - setup-health-check
+          - test-status
+          - test-scan
+        future_scenario_paths:
+          - udd/test-governance/setup-health-check
+          - udd/test-governance/test-status
+          - udd/test-governance/test-scan
+      - id: validate_phase_consistency
+        capability: compliance
+        increment: v1-basic
+        status: future
+        follow_up: "#51"
+        future_scenarios:
+          - test-linkage
+          - sync-dirty-marking
+          - test-status
+        future_scenario_paths:
+          - udd/test-governance/test-linkage
+          - udd/test-governance/sync-dirty-marking
+          - udd/test-governance/test-status
+  - id: agent-intelligence
+    name: Agent Intelligence
+    number: 4
+    status: planned
+    description: Adapter-neutral agent intelligence, autonomous maintenance, smart suggestions
+  - id: advanced-workflows
+    name: Advanced Workflows
+    number: 5
+    status: planned
+    description: Spec change tracking, migration tools, team collaboration features
+capabilities:
+  core-workflow:
+    name: Core Workflow
+    description: Enduring ability to author, validate, and run UDD project specs
+    current_increment: v2-phased
+    increments:
+      - version: v1-basic
+        phase: core-cli
+        number: 1
+        status: delivered
+        use_cases:
+          - validate_specs
+          - run_tests
+          - project_setup
+      - version: v1-hardening
+        phase: core-cli
+        number: 1
+        status: delivered
+        use_cases:
+          - edge_case_hardening
+      - version: v2-phased
+        phase: research-specs
+        number: 2
+        status: delivered
+        use_cases:
+          - phased_development
+  developer-experience:
+    name: Developer Experience
+    description: Enduring ability to keep local development workflows discoverable and consistent
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: research-specs
+        number: 2
+        status: delivered
+        use_cases:
+          - enforce_code_style
+          - fix_test_discovery
+  agent-workflow:
+    name: Agent Workflow
+    description: Enduring ability to keep human and agent work small, visible, and recoverable
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: research-specs
+        number: 2
+        status: delivered
+        use_cases:
+          - manage_wip
+  autonomous-development:
+    name: Autonomous Development
+    description: Enduring ability for AI agents to develop software autonomously
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: opencode-integration
+        number: 3
+        status: delivered
+        use_cases:
+          - orchestrated_iteration
+          - agent_customization
+      - version: v2-advanced
+        phase: agent-intelligence
+        number: 4
+        status: planned
+        use_cases:
+          - orchestrated_iteration_advanced
+      - version: v3-full
+        phase: advanced-workflows
+        number: 5
+        status: vision
+        use_cases: []
+  idea-management:
+    name: Idea Management
+    description: Enduring ability to capture and organize ideas
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: opencode-integration
+        number: 3
+        status: delivered
+        use_cases:
+          - capture_ideas
+  test-governance:
+    name: Test Governance
+    description: Enduring ability to track, review, and enforce test quality
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: opencode-integration
+        number: 3
+        status: planned
+        follow_up: "#55"
+        use_cases:
+          - track_test_quality
+          - prevent_regression
+          - manage_test_lifecycle
+          - enforce_quality_gates
+          - monitor_test_health
+      - version: v2-advanced
+        phase: agent-intelligence
+        number: 4
+        status: planned
+        use_cases: []
+  compliance:
+    name: Compliance & Validation
+    description: Enduring ability to validate project consistency and compliance
+    current_increment: v1-basic
+    increments:
+      - version: v1-basic
+        phase: opencode-integration
+        number: 3
+        status: planned
+        follow_up: "#51"
+        use_cases:
+          - validate_phase_consistency
+validation_rules:
+  scenario_phase_must_match_use_case_phase: true
+  use_case_phase_must_match_roadmap_phase: true
+  allow_future_phase_planning: true
+  strict_mode: false
+  max_phase_ahead: 1
+traceability:
+  require_test_per_scenario: true
+  require_journey_per_use_case: true
+  require_use_case_per_capability: true
+backlog_journeys:
+  - id: beads-plan-workflow
+    status: future
+    follow_up: "#52"
+    reason: Doctor/health recovery and orchestration implementation are deferred.
+  - id: recover-from-drift
+    status: future
+    follow_up: "#52"
+    reason: Recovery scenarios and commands are deferred to the diagnostics slice.
+  - id: traceability-compliance
+    status: future
+    follow_up: "#51"
+    reason: Traceability CLI validation is deferred to the phase/traceability slice.

--- a/specs/system-boundary.yml
+++ b/specs/system-boundary.yml
@@ -1,0 +1,58 @@
+# System boundary definition for UDD source-of-truth traceability
+# Boundary subject must match decisions: 'udd-core'
+boundary_subject: udd-core
+
+# What is considered in scope for udd-core (traceability artifacts only)
+in_scope:
+  - product/actors.md
+  - specs/features
+  - specs/use-cases
+  - specs/requirements
+  - specs/components
+  - specs/trace-slices
+  - tests
+  - specs/.udd/manifest.yml
+  - product/journeys
+
+# Explicitly excluded from udd-core to avoid scope creep
+out_of_scope:
+  - implementation_code
+  - deployment_infra
+  - runtime_services
+
+# External actors and systems that interact with udd-core
+external_actors:
+  - name: Reviewer
+    type: human
+    description: "Human reviewer who validates traceability and spec-to-test mapping"
+
+external_systems:
+  - id: CI_System
+    type: external_system
+    description: "Continuous Integration system that runs tests and checks (eg. GitHub Actions, Jenkins)"
+  - id: Hosted_DB
+    type: external_system
+    description: "Hosted database used by implementation environments (treated as external to udd-core)"
+
+# Validation rules used by udd lint / udd check
+validation:
+  - id: boundary_subject_exists
+    description: "specs/system-boundary.yml must declare boundary_subject 'udd-core'"
+    rule: "boundary_subject == 'udd-core'"
+  - id: in_scope_enumerates_artifacts
+    description: "in_scope must include spec artifacts: specs/features, tests, specs/.udd/manifest.yml"
+    rule: "contains(in_scope, 'specs/features') and contains(in_scope, 'tests') and contains(in_scope, 'specs/.udd/manifest.yml')"
+  - id: external_systems_minimum
+    description: "There must be at least two external_system entries (CI_System, Hosted_DB recommended)"
+    rule: "length(external_systems) >= 2"
+  - id: no_external_as_in_scope
+    description: "Detect misclassification where known external systems are placed in in_scope"
+    rule: "not any(in_scope contains item where item in ['Hosted_DB','CI_System'])"
+
+# Notes and references
+notes:
+  - source_evidence:
+    - .sisyphus/evidence/phase2/task-2-boundary.md
+    - .sisyphus/evidence/phase2/task-2-leak.md
+    - .sisyphus/notepads/udd-sysml-traceability-phase2/decisions.md
+  - "Architecture documentation for the broader concept model is deferred to #50."

--- a/specs/trace-slices/capture-ideas-inbox.md
+++ b/specs/trace-slices/capture-ideas-inbox.md
@@ -1,0 +1,55 @@
+# Trace Slice: Capture Ideas Inbox
+
+## Purpose
+
+This slice proves one complete derivation path for existing UDD behavior without
+inventing new product behavior.
+
+## Selected Slice
+
+- Persona: `developer` in `product/actors.md`
+- Journey: `capture-ideas` in `product/journeys/capture-ideas.md`
+- Use case: `capture_ideas` in `specs/use-cases/capture_ideas.yml`
+- Scenario: `udd/cli/inbox/add_item_via_cli` in `specs/features/udd/cli/inbox/add_item_via_cli.feature`
+- E2E test: `tests/e2e/udd/cli/inbox/add_item_via_cli.e2e.test.ts`
+- Component: `cli-inbox-command` in `specs/components/cli-inbox-command.yml`
+- Requirement: `persist_inbox_item` in `specs/requirements/persist_inbox_item.yml`
+
+## Forward Path
+
+`developer` -> `capture-ideas` -> `capture_ideas` ->
+`udd/cli/inbox/add_item_via_cli` ->
+`tests/e2e/udd/cli/inbox/add_item_via_cli.e2e.test.ts` ->
+`cli-inbox-command` -> `persist_inbox_item`
+
+## Reverse Path
+
+`persist_inbox_item` -> `cli-inbox-command` ->
+`tests/e2e/udd/cli/inbox/add_item_via_cli.e2e.test.ts` ->
+`udd/cli/inbox/add_item_via_cli` -> `capture_ideas` ->
+`capture-ideas` -> `developer`
+
+## Rebuild Notes
+
+To rebuild this behavior from the spec, start from the scenario and requirement:
+
+- The scenario defines the user-visible command behavior and expected inbox state.
+- The E2E test proves the command in an isolated project workspace and verifies
+  observable command output plus the resulting inbox file state.
+- The component identifies the command boundary and source file responsible for
+  delivery.
+- The requirement records persistence and confirmation obligations without
+  duplicating the scenario's Gherkin text.
+
+## Conflicts Found
+
+- `product/journeys/capture-ideas.md` previously linked directly to the scenario
+  file from the journey step. This bypassed the use-case layer, so this slice now
+  routes the journey through `capture_ideas`.
+- `specs/traceability-contract.yml` described requirements but did not define
+  components as first-class trace artifacts. The contract now includes the
+  component artifact and scenario-test-component-requirement queries needed by
+  the canonical chain.
+- Architecture documentation for the full derivation model is deferred to #50.
+  This slice is the current repo-native example for component and requirement
+  hops.

--- a/specs/traceability-contract.yml
+++ b/specs/traceability-contract.yml
@@ -1,0 +1,160 @@
+# Traceability contract for UDD
+# Defines artifact schemas, forward/reverse trace queries, and invalidation rules
+
+artifacts:
+  persona:
+    required_fields: [id, name]
+    optional_fields: [description, goals, contact]
+    description: |
+      Human actor definitions used by journeys and use_cases. "id" is canonical key.
+
+  journey:
+    required_fields: [id, actor, goal, steps]
+    optional_fields: [summary, tags]
+    description: |
+      High-level user journeys. "actor" must reference persona.id. "steps" list use_case ids or human steps.
+
+  use_case:
+    required_fields: [id, name, actors, outcomes]
+    optional_fields: [summary, tags, scenario_paths]
+    description: |
+      Use cases connect journeys to scenarios. "actors" list persona ids.
+      "outcomes[].scenarios" lists canonical scenario ids. "outcomes[].scenario_paths"
+      stores feature-path lookups used by the current CLI compatibility layer.
+
+  scenario:
+    required_fields: [id, title, feature_path]
+    optional_fields: [tags, description]
+    description: |
+      Scenario metadata representing a Gherkin scenario. "feature_path" points to the authoritative .feature file.
+
+  e2e_test:
+    required_fields: [id, scenario_path, status]
+    optional_fields: [last_run, runner]
+    description: |
+      Test harness mapping to a scenario. "scenario_path" must match scenario.feature_path or contain scenario id in path.
+
+  component:
+    required_fields: [id, name, responsibilities, supported_use_cases, supported_scenarios]
+    optional_fields: [owner, source, public_interfaces, requirements, tests]
+    description: |
+      Implementation ownership artifact. Components link tested scenarios to the requirements they deliver.
+
+  test_review:
+    required_fields: [id, test_id, scenario_path, checks]
+    optional_fields: [reviewer, created_at]
+    description: |
+      Review artifacts validating test fidelity against scenario. Must reference test_id and scenario_path.
+
+  requirement:
+    required_fields: [id, type, feature, description, scenarios]
+    optional_fields: [key, priority, owner, components, tests]
+    description: |
+      Requirements linked to scenarios and components. "scenarios" lists scenario ids covered by this requirement.
+
+trace_queries:
+  forward:
+    - name: persona_to_journeys
+      description: Find journeys for a persona
+      query: "Find journey where journey.actor = <persona.id>"
+
+    - name: journey_to_use_cases
+      description: Resolve use_cases from journey.steps
+      query: "For journey.id = <id>, map journey.steps -> use_case.id"
+
+    - name: use_case_to_scenarios
+      description: Find scenarios declared in a use_case outcome
+      query: "Find scenario.id in use_case.outcomes[].scenarios; use use_case.outcomes[].scenario_paths for feature file lookup"
+
+    - name: scenario_to_tests
+      description: Find tests that target a scenario
+      query: "Find e2e_test where e2e_test.scenario_path contains <scenario.id> or equals <scenario.feature_path>"
+
+    - name: test_to_components
+      description: Find components responsible for a tested scenario
+      query: "Find component where component.tests contains <e2e_test.path> or component.supported_scenarios contains <scenario.id>"
+
+    - name: component_to_requirements
+      description: Find requirements owned by a component
+      query: "Find requirement where requirement.components contains <component.id> or component.requirements contains requirement.id"
+
+    - name: requirement_impact
+      description: From a requirement, find impacted scenarios, tests, journeys, personas
+      query: "Find all components, e2e_tests, scenarios, use_cases, journeys, and personas reachable through requirement.components and requirement.scenarios"
+
+  reverse:
+    - name: test_to_scenario
+      description: Find scenario related to a test
+      query: "Find scenario where scenario.feature_path = <e2e_test.scenario_path> or <e2e_test.scenario_path> contains scenario.id"
+
+    - name: scenario_to_use_case
+      description: Find use_cases that reference a scenario
+      query: "Find use_case where use_case.outcomes[].scenarios contains <scenario.id>"
+
+    - name: component_to_test
+      description: Find tests associated with a component
+      query: "Find e2e_test where component.tests contains e2e_test.path"
+
+    - name: requirement_to_component
+      description: Find components that deliver a requirement
+      query: "Find component where requirement.components contains component.id or component.requirements contains requirement.id"
+
+    - name: use_case_to_journeys
+      description: Find journeys that include a use_case
+      query: "Find journey where journey.steps references <use_case.id>"
+
+    - name: journey_to_persona
+      description: Find persona for a journey
+      query: "Find persona where persona.id = <journey.actor>"
+
+    - name: failing_tests_to_requirements
+      description: From failing tests, find linked requirements
+      query: "Find requirement where requirement.scenarios intersects (tests -> scenario ids)"
+
+invalidation_rules:
+  # Each rule declares which missing field(s) cause ERROR vs WARN and short explanation
+  - artifact: persona
+    missing:
+      id: {level: ERROR, message: "Cannot reference persona in journey.actor; forward trace breaks"}
+      name: {level: WARN, message: "Display name unavailable for journey documentation"}
+
+  - artifact: journey
+    missing:
+      actor: {level: ERROR, message: "Cannot trace to persona; reverse trace from journey fails"}
+      steps: {level: ERROR, message: "Journey has no actionable steps; cannot map to use_cases"}
+
+  - artifact: use_case
+    missing:
+      id: {level: ERROR, message: "Cannot reference use_case in journey.steps; forward trace breaks"}
+      actors: {level: ERROR, message: "Cannot trace to persona; requirement-to-persona trace fails"}
+      outcomes: {level: ERROR, message: "No scenario references; use_case not connected to graph"}
+
+  - artifact: scenario
+    missing:
+      id: {level: ERROR, message: "Cannot reference scenario in use_case.outcomes; graph edge missing"}
+      feature_path: {level: ERROR, message: "Cannot locate scenario file for test mapping"}
+
+  - artifact: e2e_test
+    missing:
+      scenario_path: {level: ERROR, message: "Test not linked to scenario; traceability broken"}
+      status: {level: ERROR, message: "Cannot determine if test is passing for reverse trace"}
+
+  - artifact: component
+    missing:
+      id: {level: ERROR, message: "Cannot reference component from requirements; ownership trace breaks"}
+      supported_scenarios: {level: ERROR, message: "Component not linked to scenario responsibility; test-to-component trace breaks"}
+      responsibilities: {level: WARN, message: "Component responsibility unavailable for rebuild guidance"}
+
+  - artifact: test_review
+    missing:
+      test_id: {level: ERROR, message: "Review not linked to test; quality gate ineffective"}
+      scenario_path: {level: ERROR, message: "Cannot verify scenario fidelity; mapping unconfirmed"}
+
+  - artifact: requirement
+    missing:
+      id: {level: ERROR, message: "Cannot reference requirement from components; implementation contract trace breaks"}
+      feature: {level: ERROR, message: "Cannot group requirements; impact analysis incomplete"}
+      description: {level: ERROR, message: "No specification available; implementation guidance missing"}
+      components: {level: ERROR, message: "Requirement not linked to a component; ownership trace breaks"}
+
+rules_version: 1

--- a/specs/use-cases/agent_customization.yml
+++ b/specs/use-cases/agent_customization.yml
@@ -1,15 +1,41 @@
 id: agent_customization
 name: Agent Customization
-summary: "Customize the GitHub Copilot agent for UDD"
+summary: Configure agent adapters to reuse shared UDD workflow guidance
+phase: 3
 actors:
-  - user
+  - developer
 outcomes:
-  - description: "Agent has access to project status"
+  - description: Agent has access to project status
     scenarios:
-      - "udd/agent/status_prompt"
-  - description: "Agent guides user through UDD process"
+      - status_prompt
+    scenario_paths:
+      - udd/agent/status_prompt
+  - description: Agent guides user through UDD process
     scenarios:
-      - "udd/agent/guide_user"
-  - description: "Codex hooks can be installed for UDD-aware agent sessions"
+      - guide_user
+    scenario_paths:
+      - udd/agent/guide_user
+  - description: Codex hooks can be installed for UDD-aware agent sessions
     scenarios:
-      - "udd/cli/codex_hooks"
+      - codex_hooks
+    scenario_paths:
+      - udd/cli/codex_hooks
+future_outcomes:
+  - description: OpenCode adapter can check deep status
+    follow_up: "#54"
+    scenarios:
+      - status_deep
+    scenario_paths:
+      - opencode/tools/status_deep
+  - description: OpenCode adapter can get next recommendation
+    follow_up: "#54"
+    scenarios:
+      - next_recommendation
+    scenario_paths:
+      - opencode/tools/next_recommendation
+  - description: OpenCode adapter can list all issues
+    follow_up: "#54"
+    scenarios:
+      - issues_list
+    scenario_paths:
+      - opencode/tools/issues_list

--- a/specs/use-cases/capture_ideas.yml
+++ b/specs/use-cases/capture_ideas.yml
@@ -1,9 +1,20 @@
 id: capture_ideas
 name: Capture Ideas
-summary: "Quickly capture raw ideas into an inbox for later triage and refinement"
+summary: Quickly capture raw ideas into an inbox for later triage and refinement
+phase: 3
 actors:
-  - user
+  - developer
 outcomes:
-  - description: "Ideas can be added to inbox via CLI"
+  - description: Ideas can be added to inbox via CLI
     scenarios:
+      - add_item_via_cli
+    scenario_paths:
       - udd/cli/inbox/add_item_via_cli
+components:
+  - cli-inbox-command
+requirements:
+  - persist_inbox_item
+trace:
+  journey: capture-ideas
+  persona: developer
+  navigation: specs/trace-slices/capture-ideas-inbox.md

--- a/specs/use-cases/edge_case_hardening.yml
+++ b/specs/use-cases/edge_case_hardening.yml
@@ -1,16 +1,25 @@
 id: edge_case_hardening
 name: Edge Case Hardening
-summary: "Link edge-case CLI and agent scenarios created during the edge-case-hardening plan"
+summary: Link edge-case CLI and agent scenarios created during the edge-case-hardening plan
+phase: 1
 actors:
   - developer
   - agent
 outcomes:
-  - description: "Edge-case CLI and agent scenarios are discoverable and linked to a use case"
+  - description: Edge-case CLI and agent scenarios are discoverable and linked to a use case
     scenarios:
-      - "udd/cli/sync_edge_cases"
-      - "udd/cli/status_edge_cases"
-      - "udd/cli/scaffold_feature"
-      - "udd/cli/orphan_detection"
-      - "udd/cli/manifest_recovery"
-      - "udd/cli/init_edge_cases"
-      - "udd/agent/query_commands"
+      - sync_edge_cases
+      - status_edge_cases
+      - scaffold_feature
+      - orphan_detection
+      - manifest_recovery
+      - init_edge_cases
+      - query_commands
+    scenario_paths:
+      - udd/cli/sync_edge_cases
+      - udd/cli/status_edge_cases
+      - udd/cli/scaffold_feature
+      - udd/cli/orphan_detection
+      - udd/cli/manifest_recovery
+      - udd/cli/init_edge_cases
+      - udd/agent/query_commands

--- a/specs/use-cases/enforce_code_style.yml
+++ b/specs/use-cases/enforce_code_style.yml
@@ -1,16 +1,23 @@
 id: enforce_code_style
 name: Enforce Code Style
-summary: "Ensure code styles are automatically applied and enforced"
+summary: Ensure code styles are automatically applied and enforced
+phase: 2
 actors:
   - developer
   - agent
 outcomes:
-  - description: "Imports are sorted automatically"
+  - description: Imports are sorted automatically
     scenarios:
-      - "udd/dev-experience/sort_imports"
-  - description: "Code formatting is consistent"
+      - sort_imports
+    scenario_paths:
+      - udd/dev-experience/sort_imports
+  - description: Code formatting is consistent
     scenarios:
-      - "udd/dev-experience/code_formatting"
-  - description: "Commits fail if style checks fail (unless overridden)"
+      - code_formatting
+    scenario_paths:
+      - udd/dev-experience/code_formatting
+  - description: Commits fail if style checks fail (unless overridden)
     scenarios:
-      - "udd/dev-experience/commit_hooks"
+      - commit_hooks
+    scenario_paths:
+      - udd/dev-experience/commit_hooks

--- a/specs/use-cases/enforce_quality_gates.yml
+++ b/specs/use-cases/enforce_quality_gates.yml
@@ -1,0 +1,26 @@
+id: enforce_quality_gates
+name: Enforce Quality Gates
+summary: Ensure code meets defined quality gates (coverage thresholds, no new flaky tests) before merging
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: CI enforces coverage and pass-rate thresholds
+    follow_up: "#55"
+    scenarios:
+      - ci-validation
+    scenario_paths:
+      - udd/test-governance/ci-validation
+  - description: PRs show test approval and status
+    follow_up: "#55"
+    scenarios:
+      - test-approval
+    scenario_paths:
+      - udd/test-governance/test-approval
+  - description: Integration with status checks for gate enforcement
+    follow_up: "#55"
+    scenarios:
+      - status-integration
+    scenario_paths:
+      - udd/test-governance/status-integration

--- a/specs/use-cases/fix_test_discovery.yml
+++ b/specs/use-cases/fix_test_discovery.yml
@@ -1,12 +1,17 @@
 id: fix_test_discovery
 name: Fix Test Discovery
-summary: "Ensure tests are detected by VS Code extensions"
+summary: Ensure tests are detected by VS Code extensions
+phase: 2
 actors:
   - developer
 outcomes:
-  - description: "Vitest extension shows all scenarios"
+  - description: Vitest extension shows all scenarios
     scenarios:
-      - "udd/dev-experience/test_discovery/vscode_detection"
-  - description: "Test status is visible in the editor"
+      - vscode_detection
+    scenario_paths:
+      - udd/dev-experience/test_discovery/vscode_detection
+  - description: Test status is visible in the editor
     scenarios:
-      - "udd/dev-experience/test_discovery/editor_status"
+      - editor_status
+    scenario_paths:
+      - udd/dev-experience/test_discovery/editor_status

--- a/specs/use-cases/manage_test_lifecycle.yml
+++ b/specs/use-cases/manage_test_lifecycle.yml
@@ -1,0 +1,26 @@
+id: manage_test_lifecycle
+name: Manage Test Lifecycle
+summary: Define, run, retire, and review tests across their lifecycle with clear ownership and automation
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: Tests have lifecycle states (draft, active, deprecated)
+    follow_up: "#55"
+    scenarios:
+      - test-review
+    scenario_paths:
+      - udd/test-governance/test-review
+  - description: Hooks and CI integrate with lifecycle events
+    follow_up: "#55"
+    scenarios:
+      - hooks-installation
+    scenario_paths:
+      - udd/test-governance/hooks-installation
+  - description: Pre-commit tooling respects test lifecycle
+    follow_up: "#55"
+    scenarios:
+      - pre-commit-validation
+    scenario_paths:
+      - udd/test-governance/pre-commit-validation

--- a/specs/use-cases/manage_wip.yml
+++ b/specs/use-cases/manage_wip.yml
@@ -1,13 +1,18 @@
 id: manage_wip
 name: Manage Work In Progress
-summary: "Help developers avoid accumulating too many changes at once"
+summary: Help developers avoid accumulating too many changes at once
+phase: 2
 actors:
   - developer
   - agent
 outcomes:
-  - description: "Agent warns when too many files are changed"
+  - description: Agent warns when too many files are changed
     scenarios:
-      - "udd/agent/wip_enforcement/warn_on_large_changeset"
-  - description: "Developer is encouraged to commit small changes"
+      - warn_on_large_changeset
+    scenario_paths:
+      - udd/agent/wip_enforcement/warn_on_large_changeset
+  - description: Developer is encouraged to commit small changes
     scenarios:
-      - "udd/agent/wip_enforcement/encourage_small_commits"
+      - encourage_small_commits
+    scenario_paths:
+      - udd/agent/wip_enforcement/encourage_small_commits

--- a/specs/use-cases/monitor_test_health.yml
+++ b/specs/use-cases/monitor_test_health.yml
@@ -1,0 +1,26 @@
+id: monitor_test_health
+name: Monitor Test Health
+summary: Continuously monitor test suite health and surface alerts for failures, slow tests, and flakiness
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: Health checks run periodically
+    follow_up: "#55"
+    scenarios:
+      - setup-health-check
+    scenario_paths:
+      - udd/test-governance/setup-health-check
+  - description: Alerts are created for degrading test health
+    follow_up: "#55"
+    scenarios:
+      - test-status
+    scenario_paths:
+      - udd/test-governance/test-status
+  - description: Slow tests are identified for optimization
+    follow_up: "#55"
+    scenarios:
+      - test-scan
+    scenario_paths:
+      - udd/test-governance/test-scan

--- a/specs/use-cases/orchestrated_iteration.yml
+++ b/specs/use-cases/orchestrated_iteration.yml
@@ -1,6 +1,8 @@
 id: orchestrated_iteration
 name: Orchestrated Iteration
-summary: Enable continuous autonomous development using an orchestrator agent that coordinates worker agents via the OpenCode SDK, iterating until project completion or error state.
+summary: Enable continuous autonomous development using an orchestrator agent that coordinates
+  worker agents through a shared UDD integration contract and adapter-specific runtime.
+phase: 3
 actors:
   - developer
   - orchestrator_agent
@@ -8,13 +10,21 @@ actors:
 outcomes:
   - description: Orchestrator delegates work to worker and monitors completion
     scenarios:
+      - iterate_until_complete
+    scenario_paths:
       - opencode/orchestration/iterate_until_complete
   - description: Orchestrator handles errors and preserves session state
     scenarios:
+      - stop_on_error
+    scenario_paths:
       - opencode/orchestration/stop_on_error
   - description: Orchestrator uses structured status to make decisions
     scenarios:
+      - udd_status_tool
+    scenario_paths:
       - opencode/tools/udd_status_tool
   - description: Developer can configure iteration limits and pause conditions
     scenarios:
+      - configurable_iteration
+    scenario_paths:
       - opencode/orchestration/configurable_iteration

--- a/specs/use-cases/phased_development.yml
+++ b/specs/use-cases/phased_development.yml
@@ -1,16 +1,23 @@
 id: phased_development
 name: Phased Development
-summary: "Support incremental delivery by allowing scenarios to be marked as planned for future phases"
+summary: Support incremental delivery by allowing scenarios to be marked as planned for future phases
+phase: 2
 actors:
   - developer
   - agent
 outcomes:
-  - description: "Scenarios can be tagged as @phase:N to defer to future phases"
+  - description: Scenarios can be tagged as @phase:N to defer to future phases
     scenarios:
+      - wip_tag_support
+    scenario_paths:
       - udd/cli/wip_support/wip_tag_support
-  - description: "Status command shows deferred items separately from blocking failures"
+  - description: Status command shows deferred items separately from blocking failures
     scenarios:
+      - status_shows_wip
+    scenario_paths:
       - udd/cli/wip_support/status_shows_wip
-  - description: "Agent understands deferred scenarios are intentionally deferred"
+  - description: Agent understands deferred scenarios are intentionally deferred
     scenarios:
+      - agent_wip_awareness
+    scenario_paths:
       - udd/agent/wip_support/agent_wip_awareness

--- a/specs/use-cases/prevent_regression.yml
+++ b/specs/use-cases/prevent_regression.yml
@@ -1,0 +1,27 @@
+id: prevent_regression
+name: Prevent Regression
+summary: Detect and block regressions by linking tests to features and enforcing lightweight
+  diff-based test runs
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: Changed features trigger targeted tests
+    follow_up: "#55"
+    scenarios:
+      - feature-change-detection
+    scenario_paths:
+      - udd/test-governance/feature-change-detection
+  - description: Pull requests run regression checks
+    follow_up: "#55"
+    scenarios:
+      - ci-validation
+    scenario_paths:
+      - udd/test-governance/ci-validation
+  - description: Support for marking dirty tests when relevant files change
+    follow_up: "#55"
+    scenarios:
+      - dirty-marking
+    scenario_paths:
+      - udd/test-governance/dirty-marking

--- a/specs/use-cases/project_setup.yml
+++ b/specs/use-cases/project_setup.yml
@@ -1,13 +1,18 @@
 id: project_setup
 name: Project Setup
-summary: "Initialize and configure the UDD project for development"
+summary: Initialize and configure the UDD project for development
+phase: 1
 actors:
   - developer
   - agent
 outcomes:
-  - description: "Dependencies are installed"
+  - description: Dependencies are installed
     scenarios:
-      - "udd/cli/setup"
-  - description: "CLI tool is linked and available globally"
+      - setup
+    scenario_paths:
+      - udd/cli/setup
+  - description: CLI tool is linked and available globally
     scenarios:
-      - "udd/cli/setup"
+      - setup
+    scenario_paths:
+      - udd/cli/setup

--- a/specs/use-cases/run_tests.yml
+++ b/specs/use-cases/run_tests.yml
@@ -1,12 +1,17 @@
 id: run_tests
 name: Run Tests
-summary: "Execute tests and view project status to track implementation progress"
+summary: Execute tests and view project status to track implementation progress
+phase: 1
 actors:
   - user
 outcomes:
-  - description: "Tests can be executed via CLI"
+  - description: Tests can be executed via CLI
     scenarios:
+      - run_tests
+    scenario_paths:
       - udd/cli/run_tests
-  - description: "Project status is visible via CLI"
+  - description: Project status is visible via CLI
     scenarios:
+      - check_status
+    scenario_paths:
       - udd/cli/check_status

--- a/specs/use-cases/track_test_quality.yml
+++ b/specs/use-cases/track_test_quality.yml
@@ -1,0 +1,26 @@
+id: track_test_quality
+name: Track Test Quality
+summary: Collect and surface test quality metrics (coverage, flakiness, pass rate) for project visibility
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: Test coverage metrics are available
+    follow_up: "#55"
+    scenarios:
+      - health-metrics
+    scenario_paths:
+      - udd/test-governance/health-metrics
+  - description: Flaky test detection is reported
+    follow_up: "#55"
+    scenarios:
+      - test-scan
+    scenario_paths:
+      - udd/test-governance/test-scan
+  - description: Historical pass rate is tracked
+    follow_up: "#55"
+    scenarios:
+      - test-status
+    scenario_paths:
+      - udd/test-governance/test-status

--- a/specs/use-cases/validate_phase_consistency.yml
+++ b/specs/use-cases/validate_phase_consistency.yml
@@ -1,0 +1,26 @@
+id: validate_phase_consistency
+name: Validate Phase Consistency
+summary: Ensure roadmap phases, scenarios, and use-cases remain consistent as the project evolves
+phase: 3
+actors:
+  - developer
+  - agent
+future_outcomes:
+  - description: Use-cases reference scenarios with matching phase tags
+    follow_up: "#51"
+    scenarios:
+      - test-linkage
+    scenario_paths:
+      - udd/test-governance/test-linkage
+  - description: Detects mismatches between journey phase and use-case phase
+    follow_up: "#51"
+    scenarios:
+      - sync-dirty-marking
+    scenario_paths:
+      - udd/test-governance/sync-dirty-marking
+  - description: Provides reports for roadmap owners when inconsistencies appear
+    follow_up: "#51"
+    scenarios:
+      - test-status
+    scenario_paths:
+      - udd/test-governance/test-status

--- a/specs/use-cases/validate_specs.yml
+++ b/specs/use-cases/validate_specs.yml
@@ -1,20 +1,28 @@
-id: "validate_specs"
-name: "Validate Specs"
-summary: "Ensure that the spec files in the repository follow the defined structure and schemas."
+id: validate_specs
+name: Validate Specs
+summary: Ensure that the spec files in the repository follow the defined structure and schemas.
+phase: 1
 actors:
-  - "developer"
-  - "agent"
+  - developer
+  - agent
 outcomes:
-  - description: "Valid specs pass linting"
+  - description: Valid specs pass linting
     scenarios:
-      - "udd/cli/lint_valid_specs"
-  - description: "Invalid specs report errors"
+      - lint_valid_specs
+    scenario_paths:
+      - udd/cli/lint_valid_specs
+  - description: Invalid specs report errors
     scenarios:
-      - "udd/cli/lint_invalid_specs"
-
-  - description: "Validation guidance can be discovered for spec authoring"
+      - lint_invalid_specs
+    scenario_paths:
+      - udd/cli/lint_invalid_specs
+  - description: Validation guidance can be discovered for spec authoring
     scenarios:
-      - "udd/cli/validation/discover_feature"
-  - description: "Scenario completeness checks can be validated"
+      - discover_feature
+    scenario_paths:
+      - udd/cli/validation/discover_feature
+  - description: Scenario completeness checks can be validated
     scenarios:
-      - "udd/cli/validation/validate_completeness"
+      - validate_completeness
+    scenario_paths:
+      - udd/cli/validation/validate_completeness

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -387,7 +387,14 @@ export async function getProjectStatus(): Promise<ProjectStatus> {
 			id: string;
 			name: string;
 			scenarios?: string[];
-			outcomes?: (string | { description: string; scenarios?: string[] })[];
+			outcomes?: (
+				| string
+				| {
+						description: string;
+						scenarios?: string[];
+						scenario_paths?: string[];
+				  }
+			)[];
 		};
 
 		const useCaseStatus: UseCaseStatus = {
@@ -410,7 +417,7 @@ export async function getProjectStatus(): Promise<ProjectStatus> {
 						`Outcome "${outcome}" is in legacy format. Expected object with 'description' and 'scenarios'.`,
 					);
 				} else {
-					const scenarios = outcome.scenarios || [];
+					const scenarios = outcome.scenario_paths ?? outcome.scenarios ?? [];
 					let isSatisfied = true;
 					let hasDeferred = false;
 					if (scenarios.length === 0) {

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -60,8 +60,9 @@ export async function validateSpecs(): Promise<ValidationResult> {
 				// Check scenarios exist
 				if (result.data.outcomes) {
 					for (const outcome of result.data.outcomes) {
-						if (outcome.scenarios) {
-							for (const scenarioPath of outcome.scenarios) {
+						const scenarioPaths = outcome.scenario_paths ?? outcome.scenarios;
+						if (scenarioPaths) {
+							for (const scenarioPath of scenarioPaths) {
 								// Mark as referenced (format: area/feature/slug)
 								referencedScenarios.add(scenarioPath);
 								const featurePath = path.join(

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export const UseCaseSpecSchema = z.object({
 			z.object({
 				description: z.string(),
 				scenarios: z.array(z.string()).optional(),
+				scenario_paths: z.array(z.string()).optional(),
 			}),
 		)
 		.optional(),
@@ -62,6 +63,7 @@ export const TechnicalRequirementSchema = z.object({
 	feature: z.string(),
 	use_cases: z.array(z.string()).optional(),
 	scenarios: z.array(z.string()),
+	scenario_paths: z.array(z.string()).optional(),
 	description: z.string(),
 	notes: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## Objective

Closes #49.

Land the first focused salvage increment from the PR #45 side-branch stack: the product/source-of-truth foundation from `origin/codex/source-of-truth-cleanup-base`, without importing broad CLI, test-governance, OpenCode, generated local state, or unrelated implementation changes.

Goal file: `goals/006-source-of-truth-foundation.md`

## Imported

- `product/README.md`, `product/actors.md`, `product/concept.md`, `product/constraints.md`
- `product/journeys/*.md`
- `specs/VISION.md`
- `specs/roadmap.yml`
- `specs/system-boundary.yml`
- `specs/traceability-contract.yml`
- `specs/journey-map.schema.yml`
- `specs/journey-map.example.yml`
- `specs/components/cli-inbox-command.yml`
- `specs/requirements/persist_inbox_item.yml`
- `specs/trace-slices/capture-ideas-inbox.md`
- `specs/use-cases/*.yml` updates and new use-case files
- Tiny compatibility updates in `src/lib/status.ts`, `src/lib/validator.ts`, and `src/types.ts` so current CLI validation resolves canonical `scenarios` ids through `scenario_paths`.

## Intentionally Excluded

- Generated/local artifacts: `.udd/config.yml`, `.memsearch.yaml`, `bun.lock`
- Broad implementation changes: `src/commands/*`, `bin/*`, new CLI features, test-governance implementation, OpenCode implementation
- Test implementation and governance suites: `tests/*`
- Architecture/process docs tracked separately by #50 and #53: `docs/architecture/*`, `docs/process/*`, examples
- Doctor/health, phase/traceability CLI, test-governance, and CI gate work tracked by #51, #52, #55, and #56

## Review Follow-up

Gemini review comments were addressed by:

- Splitting roadmap and use-case scenario references into canonical scenario ids (`scenarios`) and feature-path lookups (`scenario_paths`).
- Aligning `specs/use-cases/*.yml` `phase` values with `specs/roadmap.yml` phase assignments.
- Making use-case and persona ids explicitly snake_case in the journey map schema and adding `Actor IDs` to journey files.
- Rewriting `traceability-compliance` as future product intent routed through #51 instead of claiming current strict validation exists.

Independent Codex end-user review was run after the Gemini fixes. Initial blockers were addressed, and the follow-up review reported no remaining blocking or high findings.

## Branch-Name Reconciliation

GitHub reports the repository default branch as `master` (verified 2026-05-29 through the GitHub API and `git ls-remote --symref origin HEAD`). This PR removes stale branch strategy/current-phase state from `specs/VISION.md`; mutable branch, phase, and progress state belongs in `specs/roadmap.yml`, status output, and goal documents.

## Validation

Commands run:

```bash
git fetch origin
git ls-remote --symref origin HEAD
curl -s https://api.github.com/repos/rothnic/udd
./bin/udd status
./bin/udd lint
node_modules/.bin/tsc --noEmit
scripts/codex-verify.sh
git diff --cached --check
git diff --name-only origin/master...HEAD | rg '^(bin/|tests/|docs/architecture/|docs/process/|examples/|\.udd/config\.yml|\.memsearch\.yaml|bun\.lock|\.opencode/)'
```

Results:

- Default branch: `master`.
- Scope diff check: no excluded paths matched.
- `./bin/udd lint`: passes, `All specs are valid`.
- `node_modules/.bin/tsc --noEmit`: passes.
- `scripts/codex-verify.sh`: passes, 33 test files / 256 tests.
- `git diff --cached --check`: passes before commit.
- `./bin/udd status`: exits 0 and reports expected repo health debt for this foundation-only slice: `13/21 outcomes unsatisfied`, `15 scenario(s) stale`, `6 outcome(s) deferred to future phase`, and imported journeys still `needs sync` because generated manifest state is intentionally excluded.

## Deferred Decisions

- #50: Architecture and process documentation alignment.
- #51: Phase and traceability CLI foundation.
- #52: Doctor and health diagnostics.
- #53: Examples and sample products.
- #54: OpenCode and shared agent integration.
- #55: Test-governance gates.
- #56: Package and tooling cleanup.

## Next Recommended Issue

After merge, continue with #51 if the priority is executable phase/traceability validation, or #50 if the priority is architecture/process documentation alignment.
