### PR TITLE
Add traceability model recommendation and next-work-chunk docs

### DIFF
--- a/docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md
+++ b/docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md
@@ -1,0 +1,131 @@
+# Next Work Chunk Recommendation (2026-05-24)
+
+## Objective
+
+Recommend the next smallest, high-leverage chunk of work after recent PR activity, aligned with UDD's project goals and user needs.
+
+## Inputs Reviewed
+
+- Current status snapshot (`npm run udd -- status`) on 2026-05-24.
+- Recent local commit/PR history from `git log --oneline --decorate -n 20`.
+- Prior assessment and audit artifacts:
+  - `docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md`
+  - `docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.md`
+  - `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
+  - `goals/006-source-of-truth-foundation.md`
+- Current source-of-truth docs:
+  - `README.md`
+  - `specs/VISION.md`
+  - `specs/use-cases/*.yml`
+
+## What Recent Work Indicates
+
+1. **PR #46 (Codex hooks) and setup/docs cleanup landed**
+   - Local invocation clarity and hook installation improved.
+2. **PR #48 added the side-branch stack audit and follow-up goals**
+   - A concrete salvage sequence now exists, with source-of-truth foundation first.
+3. **Status still shows 26/26 outcomes unsatisfied and 30 stale scenarios**
+   - Planning clarity has improved, but outcomes are still not yet implemented/verified.
+
+## Reconciliation: Current vs Future State Model
+
+## Current-state model (implemented behavior)
+
+From `udd status` and existing files, the model that is currently operational is:
+
+- `specs/use-cases/*.yml` define outcomes and map to scenario IDs.
+- `specs/features/**` define scenario behavior.
+- `tests/e2e/**` verify those scenarios.
+
+This is the chain the CLI can evaluate today.
+
+## Future-state model (intended target)
+
+Across roadmap/audit/goal docs, the intended target is a canonical source-of-truth graph:
+
+**objective (roadmap) -> use case -> product journey -> scenario -> e2e test**
+
+with explicit schema/contracts such as:
+
+- `product/*`
+- `specs/roadmap.yml`
+- `specs/system-boundary.yml`
+- `specs/traceability-contract.yml`
+- `specs/journey-map.schema.yml`
+
+## Documented drift to reconcile
+
+1. **Journey-first README vs use-case-first status reality**
+   - README describes journey-driven generation as canonical.
+   - Current status outputs and present files are still dominated by use-case + features mapping.
+2. **Branch source-of-truth drift (`main` vs `master`)**
+   - `specs/VISION.md` still references `main` workflow language.
+   - Audit/goal docs record repository default branch as `master` (as of 2026-05-19).
+3. **Traceability depth mismatch**
+   - Tracker marks canonical graph work done at lint layer, but objective-level rollups and canonical-mode clarity are still pending.
+
+## User-Need Lens
+
+Primary users and immediate needs:
+
+- **Spec authors/developers** need one unambiguous canonical structure.
+- **Maintainers/leads** need objective-level health summaries they can trust.
+- **Agents** need deterministic representation rules to avoid creating drift.
+
+The most acute user pain is uncertainty about which artifacts are authoritative during feature authoring and review.
+
+## Recommended Next Chunk (Pick Up Now)
+
+## Chunk Name
+**Source-of-Truth Reconciliation Slice 1: Canonical model declaration + compatibility policy**
+
+## Why this chunk next
+
+- It converts the existing “future-state intent” into an explicit, repo-local policy.
+- It reduces user confusion before deeper CLI/schema migrations.
+- It keeps scope narrow and directly supports Goal 006.
+
+## Scope (small and focused)
+
+1. **Canonical declaration doc update**
+   - Add one explicit “Canonical Traceability Model” section in `README.md` (or linked source-of-truth doc) that states:
+     - target chain,
+     - canonical artifacts,
+     - temporary compatibility layer.
+2. **Compatibility policy documentation**
+   - Define whether `specs/use-cases + specs/features` is:
+     - canonical now, with future migration plan, or
+     - compatibility mode pending product/journey foundation merge.
+3. **Branch naming source-of-truth decision**
+   - Resolve `main` vs `master` conflict in docs, or explicitly document a planned rename.
+4. **Status messaging alignment (minimal)**
+   - Add a compact status note or docs section explaining what status does/does not yet represent in the future model.
+
+## Explicitly out of scope for this chunk
+
+- Broad CLI behavior rewrites.
+- OpenCode orchestration features.
+- Test-governance gates.
+- Large-scale file moves/migrations.
+
+## Acceptance Criteria
+
+1. A contributor can identify canonical traceability rules in one location without ambiguity.
+2. The repository documents the active compatibility mode and migration intent.
+3. Branch naming source-of-truth no longer conflicts silently.
+4. Goal 006 in-scope foundational files remain the next implementation increment.
+
+## Suggested Implementation Order
+
+1. Draft reconciliation note and canonical declaration.
+2. Align `README.md` + `specs/VISION.md` references.
+3. Update goal/review links for consistency.
+4. Run `npm run udd -- status` and `npm run udd -- lint` to confirm no unintended behavioral regressions.
+
+## Follow-on Chunk (After this one)
+
+**Source-of-Truth Foundation Slice 2: Import foundational product/roadmap/traceability files from Goal 006 scope**
+
+## Decision
+
+**Pick up Source-of-Truth Reconciliation Slice 1 immediately** to remove ambiguity, then execute Goal 006 foundation import with reduced risk.

--- a/docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md
+++ b/docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md
@@ -1,0 +1,151 @@
+# Traceability Model Recommendation (2026-05-26)
+
+## Why This Exists
+
+The project goal is tool-agnostic, user-centered specs that define behavior independent of implementation language, so the system can be rebuilt while preserving behavior guarantees.
+
+This review evaluates existing project examples and recommends the thinnest model that preserves:
+
+- user intent clarity,
+- executable verification,
+- manageable traceability,
+- and agent-assisted gap analysis without introducing overlapping artifact layers.
+
+## Design Principle
+
+Use the **thinnest viable layered chain**:
+
+**Objective -> Use Case -> Scenario -> Test**
+
+with **Journey as optional authoring context** (not a mandatory extra layer in every flow).
+
+Why this is thinnest:
+
+1. Objective gives planning context (why).
+2. Use case groups outcomes (what value).
+3. Scenario expresses observable behavior (what system does).
+4. Test proves behavior (is it true now).
+5. Journey remains highly valuable, but can be treated as optional/source context where it improves discovery rather than a required mechanical link in every repo state.
+
+This follows project guidance to avoid unnecessary extra layers while still using SysML-informed thinking.
+
+## What Existing Docs Already Say
+
+- README describes journey-first workflow (`product/journeys -> specs -> tests`) and user-outcome framing.
+- Vision emphasizes specs as source of truth and simple/deterministic workflow.
+- SysML guide explicitly warns against adding overlapping artifact layers and promotes richer feature scenarios instead.
+- Roadmap tracker already defines canonical traceability in lint/status terms as objective -> use case -> scenario -> e2e.
+
+Taken together, the repository already leans toward a thin operational chain, but with documentation drift on where journeys are mandatory versus contextual.
+
+## Actual Project Examples Reviewed
+
+## Example A: `run_tests` (clear and thin)
+
+Artifacts:
+
+- Use case: `specs/use-cases/run_tests.yml`
+- Scenario: `specs/features/udd/cli/run_tests.feature`
+- Test: `tests/e2e/udd/cli/run_tests.e2e.test.ts`
+
+What works well:
+
+- Clean mapping from outcome -> scenario ID.
+- Scenario is user-observable behavior.
+- Test imports feature and validates CLI behavior from user perspective.
+
+Where it can improve:
+
+- Some assertions are implementation-help text checks (e.g., help output) rather than real behavior execution.
+
+Verdict: **Strong model shape** for tool-agnostic specs.
+
+## Example B: `orchestrated_iteration` (rich but mixed)
+
+Artifacts:
+
+- Use case: `specs/use-cases/orchestrated_iteration.yml`
+- Scenario file: `specs/features/opencode/orchestration/iterate_until_complete.feature`
+- Test: `tests/e2e/opencode/orchestration/iterate_until_complete.e2e.test.ts`
+
+What works well:
+
+- Clear actor-driven user/developer intent.
+- Scenario structure supports PM-style analysis and iterative orchestration expectations.
+
+Where complexity appears:
+
+- Significant simulation in tests and acceptance of dual outcomes reduces strictness of pass/fail signal.
+- Model can drift from user-observable acceptance if too much internal orchestration detail dominates.
+
+Verdict: **Useful for exploration**, but should be tightened to preserve user-observable contract semantics.
+
+## Example C: SysML-informed docs examples (best discovery behavior)
+
+Artifacts:
+
+- `docs/sysml-informed-discovery.md`
+- `docs/example-features/export_data.feature`
+- `docs/example-features/password_reset.feature`
+
+What works well:
+
+- Excellent pattern for PM/agent discovery questioning (who/what/why/alternatives/edge cases).
+- Keeps details in scenario comments rather than introducing new persistent artifact layers.
+
+Verdict: **Best model for discovery and authoring quality** when paired with the thin traceability chain.
+
+## Recommended Model for the Project
+
+## 1) Canonical persistent traceability (machine-checked)
+
+Required links:
+
+1. Objective (roadmap item)
+2. Use case (`specs/use-cases/*.yml`)
+3. Scenario ID (`specs/features/**/*.feature`)
+4. E2E test (`tests/e2e/**/*.test.ts`)
+
+This is what lint/status should enforce strictly.
+
+## 2) Optional narrative/discovery context (human-guided)
+
+- Journey docs (`product/journeys/*.md`) and SysML-style comments are strongly recommended when creating/changing features.
+- They are not required to block every build until Goal 006 foundation import is completed and conventions are finalized.
+
+## 3) Agent PM workflow
+
+For a human collaborating with an agent acting as PM:
+
+1. Agent interrogates user need (actor, job, success criteria, constraints, alternatives).
+2. Agent drafts/updates scenario(s) first (tool-agnostic behavior contract).
+3. Tests fail (red) against changed spec.
+4. Implementation changes to satisfy tests (green).
+5. Agent reports traceability and uncovered gaps.
+
+This preserves "specs guide behavior" while keeping process lightweight.
+
+## How to Avoid Overlap Going Forward
+
+1. Keep one canonical graph for enforcement.
+2. Keep journey/SysML context in comments/docs, not duplicate schemas.
+3. Require scenario IDs to be stable and referenced from use cases.
+4. Prefer user-observable Then assertions over internal implementation detail.
+5. Add explicit gap reporting in status for:
+   - unlinked scenarios,
+   - use cases without tests,
+   - objectives without active use cases.
+
+## Next Concrete Increment
+
+Implement **Source-of-Truth Reconciliation Slice 1** as a docs+policy increment:
+
+- Add one canonical "Traceability Contract" section in top-level docs.
+- Define compatibility mode explicitly (current use-case/feature/test operational chain + journey context).
+- Add one worked "change existing feature" example:
+  - edit scenario to intentionally fail test,
+  - implement,
+  - return to green,
+  - show trace links.
+
+This gives users a clear, practical, non-overlapping model before deeper schema/CLI migrations.


### PR DESCRIPTION
### Motivation

- Clarify repo-level traceability and remove ambiguity between journey-first and use-case-first workflows. 
- Narrow the next increment of work to a small, actionable reconciliation slice that documents canonical model and compatibility policy. 
- Provide maintainers and agents a deterministic, machine-checkable traceability chain to reduce drift before larger schema/CLI changes.

### Description

- Add `docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md` which recommends the next work chunk named "Source-of-Truth Reconciliation Slice 1" and lists scope, acceptance criteria, and a suggested implementation order. 
- Add `docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md` which prescribes the canonical traceability chain `Objective -> Use Case -> Scenario -> Test`, explains rationale, and gives guidance for optional journey/context usage. 
- Document compatibility policy, branch-naming source-of-truth decision points (`main` vs `master`), and guidance to keep journey/SysML context as non-blocking narrative rather than duplicated artifact layers. 
- Include next steps and an example-driven increment to validate trace links and demonstrate the recommended workflow.

### Testing

- No automated tests were run because this is a documentation-only change. 
- Recommended verification commands to run locally are `npm run udd -- status` and `npm run udd -- lint` to ensure no behavioral regressions when the policy is applied. 
- No test failures were reported as no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1329edd5b0832cbcdc78f7dc9ef999)