### PR TITLE
Add source-of-truth reconciliation goal and traceability model review docs

### DIFF
--- a/docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md
+++ b/docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md
@@ -1,0 +1,87 @@
+# Goal: Source-of-Truth Reconciliation and Spec-First Change Loop
+
+Date: 2026-05-26  
+Status: Proposed (next execution target)
+
+## Objective
+
+Establish one explicit, tool-agnostic traceability contract that keeps specs as the user-facing behavior source of truth while minimizing artifact overlap.
+
+This goal moves the project from analysis-only docs into an executable work target with concrete deliverables.
+
+## Problem This Goal Solves
+
+Current docs show drift between:
+
+- journey-first guidance in `README.md`,
+- use-case/scenario-centric operational status,
+- and future source-of-truth foundation plans.
+
+Without a single declared contract + compatibility policy, maintainers and agents can create overlapping representations.
+
+## Target Model (thin, enforceable)
+
+Canonical enforced chain:
+
+1. Objective
+2. Use Case
+3. Scenario
+4. E2E Test
+
+Optional contextual layer:
+
+- Journey + SysML-informed analysis notes, used to improve discovery quality and scenario completeness.
+
+## Deliverables
+
+1. **Canonical contract declaration**
+   - Add one source-of-truth section in top-level docs that states:
+     - canonical chain,
+     - what is strictly lint/status enforced,
+     - what is optional context.
+
+2. **Compatibility mode declaration**
+   - State clearly how current repo state maps to target model during transition.
+   - Include explicit “do not duplicate layers” guidance.
+
+3. **Worked change-loop example (red -> green)**
+   - Add one concrete example showing:
+     - modify scenario first,
+     - observe failing test,
+     - implement behavior,
+     - return to passing,
+     - confirm trace links.
+
+4. **Branch naming source-of-truth note**
+   - Resolve/document `main` vs `master` policy to avoid command ambiguity.
+
+## Acceptance Criteria
+
+- A contributor can answer “what is canonical?” from one document section.
+- A contributor can follow one concrete example of spec-first feature modification (red -> green).
+- Documentation explicitly distinguishes required traceability links vs optional context.
+- Documentation references existing foundation goal scope for next implementation slice.
+
+## Out of Scope
+
+- Broad CLI rewrites.
+- Large-scale migration of all current specs.
+- OpenCode orchestration behavior changes.
+
+## Execution References
+
+- `docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md`
+- `docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md`
+- `goals/006-source-of-truth-foundation.md`
+- `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
+- `docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.md`
+- `docs/sysml-informed-discovery.md`
+
+## Verification Commands
+
+```bash
+npm run udd -- status
+npm run udd -- lint
+```
+
+Record baseline failures explicitly in execution PR notes if they are unrelated to docs edits.

--- a/docs/project/goals/README.md
+++ b/docs/project/goals/README.md
@@ -1,0 +1,14 @@
+# Project Goals (Docs-Scoped)
+
+This directory contains execution-oriented goal documents used to turn project analysis into concrete, reviewable work targets.
+
+## Active Goals
+
+- `2026-05-26-source-of-truth-reconciliation-goal.md`
+  - Defines the next concrete goal to reconcile the source-of-truth model and preserve spec-first behavior.
+
+## Related References
+
+- `docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md`
+- `docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md`
+- `goals/006-source-of-truth-foundation.md`

--- a/docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md
+++ b/docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md
@@ -1,0 +1,136 @@
+# Next Work Chunk Recommendation (2026-05-24)
+
+## Objective
+
+Recommend the next smallest, high-leverage chunk of work after recent PR activity, aligned with UDD's project goals and user needs.
+
+## Inputs Reviewed
+
+- Current status snapshot (`npm run udd -- status`) on 2026-05-24.
+- Recent local commit/PR history from `git log --oneline --decorate -n 20`.
+- Prior assessment and audit artifacts:
+  - `docs/project/reviews/2026-05-11/GOAL_GAP_ASSESSMENT_2026-05-11.md`
+  - `docs/project/reviews/2026-05-11/ROADMAP_TRACKER_2026-05-11.md`
+  - `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md`
+  - `goals/006-source-of-truth-foundation.md`
+- Current source-of-truth docs:
+  - `README.md`
+  - `specs/VISION.md`
+  - `specs/use-cases/*.yml`
+
+## What Recent Work Indicates
+
+1. **PR #46 (Codex hooks) and setup/docs cleanup landed**
+   - Local invocation clarity and hook installation improved.
+2. **PR #48 added the side-branch stack audit and follow-up goals**
+   - A concrete salvage sequence now exists, with source-of-truth foundation first.
+3. **Status still shows 26/26 outcomes unsatisfied and 30 stale scenarios**
+   - Planning clarity has improved, but outcomes are still not yet implemented/verified.
+
+## Reconciliation: Current vs Future State Model
+
+## Current-state model (implemented behavior)
+
+From `udd status` and existing files, the model that is currently operational is:
+
+- `specs/use-cases/*.yml` define outcomes and map to scenario IDs.
+- `specs/features/**` define scenario behavior.
+- `tests/e2e/**` verify those scenarios.
+
+This is the chain the CLI can evaluate today.
+
+## Future-state model (intended target)
+
+Across roadmap/audit/goal docs, the intended target is a canonical source-of-truth graph:
+
+**objective (roadmap) -> use case -> scenario -> e2e test**
+
+with journey/SysML notes as optional authoring context that improves discovery but is not a required extra enforced layer until the foundation work explicitly promotes it. Supporting schema/contracts may include:
+
+- `product/*`
+- `specs/roadmap.yml`
+- `specs/system-boundary.yml`
+- `specs/traceability-contract.yml`
+- `specs/journey-map.schema.yml`
+
+## Documented drift to reconcile
+
+1. **Journey-first README vs use-case-first status reality**
+   - README describes journey-driven generation as canonical.
+   - Current status outputs and present files are still dominated by use-case + features mapping.
+2. **Branch source-of-truth drift (`main` vs `master`)**
+   - `specs/VISION.md` still references `main` workflow language.
+   - Audit/goal docs record repository default branch as `master` (as of 2026-05-19).
+3. **Traceability depth mismatch**
+   - Tracker marks canonical graph work done at lint layer, but objective-level rollups and canonical-mode clarity are still pending.
+
+## User-Need Lens
+
+Primary users and immediate needs:
+
+- **Spec authors/developers** need one unambiguous canonical structure.
+- **Maintainers/leads** need objective-level health summaries they can trust.
+- **Agents** need deterministic representation rules to avoid creating drift.
+
+The most acute user pain is uncertainty about which artifacts are authoritative during feature authoring and review.
+
+## Recommended Next Chunk (Pick Up Now)
+
+## Chunk Name
+**Source-of-Truth Reconciliation Slice 1: Canonical model declaration + compatibility policy**
+
+## Why this chunk next
+
+- It converts the existing “future-state intent” into an explicit, repo-local policy.
+- It reduces user confusion before deeper CLI/schema migrations.
+- It keeps scope narrow and directly supports Goal 006.
+
+## Scope (small and focused)
+
+1. **Canonical declaration doc update**
+   - Add one explicit “Canonical Traceability Model” section in `README.md` (or linked source-of-truth doc) that states:
+     - target chain,
+     - canonical artifacts,
+     - temporary compatibility layer.
+2. **Compatibility policy documentation**
+   - Define whether `specs/use-cases + specs/features` is:
+     - canonical now, with future migration plan, or
+     - compatibility mode pending product/journey foundation merge.
+3. **Branch naming source-of-truth decision**
+   - Resolve `main` vs `master` conflict in docs, or explicitly document a planned rename.
+4. **Status messaging alignment (minimal)**
+   - Add a compact status note or docs section explaining what status does/does not yet represent in the future model.
+
+## Explicitly out of scope for this chunk
+
+- Broad CLI behavior rewrites.
+- OpenCode orchestration features.
+- Test-governance gates.
+- Large-scale file moves/migrations.
+
+## Acceptance Criteria
+
+1. A contributor can identify canonical traceability rules in one location without ambiguity.
+2. The repository documents the active compatibility mode and migration intent.
+3. Branch naming source-of-truth no longer conflicts silently.
+4. Goal 006 in-scope foundational files remain the next implementation increment.
+
+## Suggested Implementation Order
+
+1. Draft reconciliation note and canonical declaration.
+2. Align `README.md` + `specs/VISION.md` references.
+3. Update goal/review links for consistency.
+4. Run `npm run udd -- status` and `npm run udd -- lint` to confirm no unintended behavioral regressions.
+
+## Follow-on Chunk (After this one)
+
+**Source-of-Truth Foundation Slice 2: Import foundational product/roadmap/traceability files from Goal 006 scope**
+
+## Decision
+
+**Pick up Source-of-Truth Reconciliation Slice 1 immediately** to remove ambiguity, then execute Goal 006 foundation import with reduced risk.
+
+
+## Execution Goal
+
+Execution Goal: `docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md`

--- a/docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md
+++ b/docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md
@@ -1,0 +1,156 @@
+# Traceability Model Recommendation (2026-05-26)
+
+## Why This Exists
+
+The project goal is tool-agnostic, user-centered specs that define behavior independent of implementation language, so the system can be rebuilt while preserving behavior guarantees.
+
+This review evaluates existing project examples and recommends the thinnest model that preserves:
+
+- user intent clarity,
+- executable verification,
+- manageable traceability,
+- and agent-assisted gap analysis without introducing overlapping artifact layers.
+
+## Design Principle
+
+Use the **thinnest viable layered chain**:
+
+**Objective -> Use Case -> Scenario -> Test**
+
+with **Journey as optional authoring context** (not a mandatory extra layer in every flow).
+
+Why this is thinnest:
+
+1. Objective gives planning context (why).
+2. Use case groups outcomes (what value).
+3. Scenario expresses observable behavior (what system does).
+4. Test proves behavior (is it true now).
+5. Journey remains highly valuable, but can be treated as optional/source context where it improves discovery rather than a required mechanical link in every repo state.
+
+This follows project guidance to avoid unnecessary extra layers while still using SysML-informed thinking.
+
+## What Existing Docs Already Say
+
+- README describes journey-first workflow (`product/journeys -> specs -> tests`) and user-outcome framing.
+- Vision emphasizes specs as source of truth and simple/deterministic workflow.
+- SysML guide explicitly warns against adding overlapping artifact layers and promotes richer feature scenarios instead.
+- Roadmap tracker already defines canonical traceability in lint/status terms as objective -> use case -> scenario -> e2e.
+
+Taken together, the repository already leans toward a thin operational chain, but with documentation drift on where journeys are mandatory versus contextual.
+
+## Actual Project Examples Reviewed
+
+## Example A: `run_tests` (clear and thin)
+
+Artifacts:
+
+- Use case: `specs/use-cases/run_tests.yml`
+- Scenario: `specs/features/udd/cli/run_tests.feature`
+- Test: `tests/e2e/udd/cli/run_tests.e2e.test.ts`
+
+What works well:
+
+- Clean mapping from outcome -> scenario ID.
+- Scenario is user-observable behavior.
+- Test imports feature and validates CLI behavior from user perspective.
+
+Where it can improve:
+
+- Some assertions are implementation-help text checks (e.g., help output) rather than real behavior execution.
+
+Verdict: **Strong model shape** for tool-agnostic specs.
+
+## Example B: `orchestrated_iteration` (rich but mixed)
+
+Artifacts:
+
+- Use case: `specs/use-cases/orchestrated_iteration.yml`
+- Scenario file: `specs/features/opencode/orchestration/iterate_until_complete.feature`
+- Test: `tests/e2e/opencode/orchestration/iterate_until_complete.e2e.test.ts`
+
+What works well:
+
+- Clear actor-driven user/developer intent.
+- Scenario structure supports PM-style analysis and iterative orchestration expectations.
+
+Where complexity appears:
+
+- Significant simulation in tests and acceptance of dual outcomes reduces strictness of pass/fail signal.
+- Model can drift from user-observable acceptance if too much internal orchestration detail dominates.
+
+Verdict: **Useful for exploration**, but should be tightened to preserve user-observable contract semantics.
+
+## Example C: SysML-informed docs examples (best discovery behavior)
+
+Artifacts:
+
+- `docs/sysml-informed-discovery.md`
+- `docs/example-features/export_data.feature`
+- `docs/example-features/password_reset.feature`
+
+What works well:
+
+- Excellent pattern for PM/agent discovery questioning (who/what/why/alternatives/edge cases).
+- Keeps details in scenario comments rather than introducing new persistent artifact layers.
+
+Verdict: **Best model for discovery and authoring quality** when paired with the thin traceability chain.
+
+## Recommended Model for the Project
+
+## 1) Canonical persistent traceability (machine-checked)
+
+Required links:
+
+1. Objective (roadmap item)
+2. Use case (`specs/use-cases/*.yml`)
+3. Scenario ID (`specs/features/**/*.feature`)
+4. E2E test (`tests/e2e/**/*.test.ts`)
+
+This is what lint/status should enforce strictly.
+
+## 2) Optional narrative/discovery context (human-guided)
+
+- Journey docs (`product/journeys/*.md`) and SysML-style comments are strongly recommended when creating/changing features.
+- They are not required to block every build until Goal 006 foundation import is completed and conventions are finalized.
+
+## 3) Agent PM workflow
+
+For a human collaborating with an agent acting as PM:
+
+1. Agent interrogates user need (actor, job, success criteria, constraints, alternatives).
+2. Agent drafts/updates scenario(s) first (tool-agnostic behavior contract).
+3. Tests fail (red) against changed spec.
+4. Implementation changes to satisfy tests (green).
+5. Agent reports traceability and uncovered gaps.
+
+This preserves "specs guide behavior" while keeping process lightweight.
+
+## How to Avoid Overlap Going Forward
+
+1. Keep one canonical graph for enforcement.
+2. Keep journey/SysML context in comments/docs, not duplicate schemas.
+3. Require scenario IDs to be stable and referenced from use cases.
+4. Prefer user-observable Then assertions over internal implementation detail.
+5. Add explicit gap reporting in status for:
+   - unlinked scenarios,
+   - use cases without tests,
+   - objectives without active use cases.
+
+## Next Concrete Increment
+
+Implement **Source-of-Truth Reconciliation Slice 1** as a docs+policy increment:
+
+- Add one canonical "Traceability Contract" section in top-level docs.
+- Define compatibility mode explicitly (current use-case/feature/test operational chain + journey context).
+- Add one worked "change existing feature" example:
+  - edit scenario to intentionally fail test,
+  - implement,
+  - return to green,
+  - show trace links.
+
+This gives users a clear, practical, non-overlapping model before deeper schema/CLI migrations.
+
+
+## Execution Goal Link
+
+- Primary execution target: `docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md`

--- a/docs/project/reviews/2026-05-29/INDEPENDENT_REVIEW_SOURCE_OF_TRUTH_RECONCILIATION.md
+++ b/docs/project/reviews/2026-05-29/INDEPENDENT_REVIEW_SOURCE_OF_TRUTH_RECONCILIATION.md
@@ -1,0 +1,85 @@
+# Independent Review: Source-of-Truth Reconciliation Progress
+
+Date: 2026-05-29
+
+## Review Purpose
+
+Review the recent thread's documentation work independently and determine whether it does what it intended to do: move the project from broad analysis toward a clear, actionable source-of-truth reconciliation goal.
+
+## Inputs Reviewed
+
+- `docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md`
+- `docs/project/goals/README.md`
+- `docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md`
+- `docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md`
+- `goals/006-source-of-truth-foundation.md`
+- Current `npm run udd -- status` output on 2026-05-29
+
+## Intended Outcome of Recent Work
+
+The recent work intended to:
+
+1. identify a clear next goal rather than only produce analysis,
+2. recommend a thin traceability model for tool-agnostic specs,
+3. avoid overlapping journey/use-case/spec models,
+4. point future implementation toward a concrete reconciliation slice.
+
+## Independent Assessment
+
+## What works
+
+1. **A concrete goal now exists.**
+   - The docs-scoped goal defines objective, problem, target model, deliverables, acceptance criteria, references, and verification commands.
+   - This resolves the earlier gap where the work was mostly analysis.
+
+2. **The recommended traceability model is appropriately thin.**
+   - The best-supported operational model is `Objective -> Use Case -> Scenario -> E2E Test`.
+   - Journey/SysML context is valuable for discovery, but should remain optional context unless promoted by a specific future schema decision.
+
+3. **The work is aligned with the user need.**
+   - The model supports a human working with an agent as a PM: ask questions, distill behavior, update specs first, watch tests fail, implement until tests pass, and report gaps.
+
+4. **The scope is correctly constrained.**
+   - The current docs avoid broad CLI rewrites, OpenCode changes, and large migrations.
+   - This is appropriate because the immediate problem is model ambiguity, not implementation capacity.
+
+## What still needs correction before implementation
+
+1. **Top-level documentation still does not contain the canonical contract.**
+   - The goal asks for this, but it has not been implemented yet.
+   - Contributors must still read dated review docs to infer the model.
+
+2. **README and VISION still need alignment.**
+   - README remains journey-first in its basic workflow explanation.
+   - VISION still contains branch naming assumptions that previous audit docs identified as drift.
+
+3. **The current status/lint baseline still shows traceability debt.**
+   - `udd status` reports 26/26 unsatisfied outcomes, 30 stale scenarios, and one orphaned scenario.
+   - `udd lint` is expected to fail until `udd/cli/codex_hooks` is linked or removed.
+
+4. **The red -> green change-loop example is not yet present in top-level user docs.**
+   - The goal identifies this deliverable, but the implementation still needs to add the actual example.
+
+## Recommended Next Step
+
+Execute `docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md` as the next work item.
+
+The smallest useful implementation slice should be:
+
+1. Add a **Canonical Traceability Contract** section to `README.md`.
+2. State current compatibility mode explicitly:
+   - enforced now: `Objective -> Use Case -> Scenario -> E2E Test`,
+   - optional discovery context: journeys and SysML-informed notes.
+3. Update `specs/VISION.md` to point to the canonical contract and resolve/default-branch wording.
+4. Add one worked example showing spec-first change after the system exists:
+   - user asks for behavior change,
+   - agent/PM updates scenario,
+   - test fails,
+   - implementation changes,
+   - test passes,
+   - status/lint confirms traceability.
+5. Leave broad source-of-truth file imports from `goals/006-source-of-truth-foundation.md` for the follow-on slice.
+
+## Decision
+
+The recent docs now provide enough direction to proceed, but they are not complete as the final user-facing model. The next PR should implement the goal by moving the canonical contract out of dated review artifacts and into stable top-level documentation.


### PR DESCRIPTION
### Motivation

- Provide a clear, executable goal to reconcile documentation drift and establish a single canonical traceability contract (spec-first behavior) for the project.
- Move analysis into a small, reviewable execution slice that declares the canonical chain and defines compatibility policy to avoid overlapping artifact layers.
- Create concrete guidance for a spec-first change loop (red -> green) and surface immediate next steps without broad CLI or schema rewrites.

### Description

- Add `docs/project/goals/2026-05-26-source-of-truth-reconciliation-goal.md` which defines the objective, target model, deliverables, acceptance criteria, and verification commands.
- Add `docs/project/goals/README.md` to register active docs-scoped goals and link the reconciliation goal.
- Add three review artifacts: `docs/project/reviews/2026-05-24/NEXT_WORK_CHUNK_2026-05-24.md`, `docs/project/reviews/2026-05-26/TRACEABILITY_MODEL_RECOMMENDATION.md`, and `docs/project/reviews/2026-05-29/INDEPENDENT_REVIEW_SOURCE_OF_TRUTH_RECONCILIATION.md` providing rationale, recommended thin model (`Objective -> Use Case -> Scenario -> Test`), and an independent assessment.
- Include verification guidance and references to existing foundation materials and the next implementation slices, plus explicit notes about branch-name policy and non-goal items.

### Testing

- Ran `npm run udd -- status` as part of review and it reported baseline traceability debt (26/26 unsatisfied outcomes, ~30 stale scenarios, and one orphaned scenario). 
- Ran `npm run udd -- lint` as part of review and it is expected to fail due to existing `udd/cli/codex_hooks` linkage issues. 
- No functional code changes were made, so no unit or e2e code tests were modified by this PR and documentation changes did not alter executable behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1329edd5b0832cbcdc78f7dc9ef999)