### PR TITLE
Add focused doctor and health diagnostics

### DIFF
--- a/bin/udd.ts
+++ b/bin/udd.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { discoverCommand } from "../src/commands/discover.js";
+import { doctorCommand } from "../src/commands/doctor.js";
+import { healthCommand } from "../src/commands/health.js";
 import { hooksCommand } from "../src/commands/hooks.js";
 import { inboxCommand } from "../src/commands/inbox.js";
 import { initCommand } from "../src/commands/init.js";
@@ -24,6 +26,8 @@ program.addCommand(statusCommand);
 program.addCommand(newCommand);
 program.addCommand(phaseCommand);
 program.addCommand(discoverCommand);
+program.addCommand(doctorCommand);
+program.addCommand(healthCommand);
 program.addCommand(validateCommand);
 program.addCommand(testCommand);
 program.addCommand(inboxCommand);

--- a/specs/features/udd/recovery/_feature.yml
+++ b/specs/features/udd/recovery/_feature.yml
@@ -1,0 +1,8 @@
+id: udd/recovery
+area: udd
+name: Recovery Diagnostics
+summary: Read-only diagnostics for identifying UDD project health and traceability drift
+use_cases:
+  - recover_from_drift
+phase: 3
+kind: core

--- a/specs/features/udd/recovery/diagnose_project_health.feature
+++ b/specs/features/udd/recovery/diagnose_project_health.feature
@@ -45,3 +45,21 @@ Feature: Diagnose Project Health
     When I run "udd health-check --json"
     Then the JSON health report should be unhealthy
     And the report should include "missing_journey" and "missing_scenario" issues
+
+  Scenario: Report malformed manifest diagnostics
+    Given a temporary project with manifest scenarios stored as a list
+    When I run "udd doctor --json"
+    Then the JSON report should identify the project as "drift-detected"
+    And the report should include a "manifest_invalid" issue
+
+  Scenario: Report null journey manifest entries without crashing
+    Given a temporary project with a null journey manifest entry
+    When I run "udd health-check --json"
+    Then the JSON health report should be unhealthy
+    And the report should include a "missing_journey" issue
+
+  Scenario: Ignore punctuation after unquoted journey scenario paths
+    Given a temporary project with an unquoted journey scenario path followed by punctuation
+    When I run "udd doctor --json"
+    Then the JSON report should identify the project as "healthy"
+    And the report should not include a "missing_scenario" issue

--- a/specs/features/udd/recovery/diagnose_project_health.feature
+++ b/specs/features/udd/recovery/diagnose_project_health.feature
@@ -1,0 +1,47 @@
+@phase:3
+Feature: Diagnose Project Health
+
+# User Need:
+#   Developers and agents need a fast, read-only command that explains whether
+#   a UDD project is initialized, partially initialized, or drifting before they
+#   choose remediation work.
+#
+# Alternatives Considered:
+#   - Keep diagnostics inside "udd status --doctor": rejected because agents need
+#     a first-class JSON contract that is separate from the broad status report.
+#   - Salvage full recovery orchestration: rejected for this slice because
+#     automated fixes and backlogs are broader than issue #52's diagnostic proof.
+#   - Add "udd doctor" plus "udd health-check": accepted because doctor can list
+#     actionable issues while health-check can provide a compact pass/fail gate.
+#
+# Success Criteria:
+#   - Doctor JSON includes a status, issue summary, and issue list.
+#   - Health-check JSON reports a healthy boolean and the same issue summary.
+#   - Real initialized temp projects produce structured diagnostics.
+#   - Partially initialized and drifted temp projects report actionable issues.
+#   - Error handling covers partial initialization without crashing.
+#   - Edge cases include stale journey manifests and missing linked scenarios.
+
+  Scenario: Report real initialized project diagnostics
+    Given a temporary project initialized with "udd init --yes"
+    When I run "udd doctor --json"
+    Then the JSON report should identify the project as "drift-detected"
+    And the report should include a "missing_scenario" issue
+
+  Scenario: Report partial initialization diagnostics
+    Given a temporary project with "specs/.udd" but no "product" directory
+    When I run "udd health-check --json"
+    Then the JSON health report should be unhealthy
+    And the report should include a "product_missing" issue
+
+  Scenario: Report drifted journey diagnostics
+    Given a temporary project with a stale journey manifest entry
+    When I run "udd doctor --json"
+    Then the JSON report should identify the project as "drift-detected"
+    And the report should include a "journey_stale" issue
+
+  Scenario: Report deleted files still referenced by the manifest
+    Given a temporary project with manifest entries for deleted journey and scenario files
+    When I run "udd health-check --json"
+    Then the JSON health report should be unhealthy
+    And the report should include "missing_journey" and "missing_scenario" issues

--- a/specs/roadmap.yml
+++ b/specs/roadmap.yml
@@ -227,6 +227,15 @@ phases:
         scenario_paths:
           - udd/compliance/phase-consistency-validation
           - udd/compliance/traceability_validation
+      - id: recover_from_drift
+        capability: recovery-diagnostics
+        increment: v1-diagnostics
+        status: delivered
+        follow_up: "#52"
+        scenarios:
+          - diagnose_project_health
+        scenario_paths:
+          - udd/recovery/diagnose_project_health
   - id: agent-intelligence
     name: Agent Intelligence
     number: 4
@@ -353,6 +362,18 @@ capabilities:
         follow_up: "#51"
         use_cases:
           - validate_phase_consistency
+  recovery-diagnostics:
+    name: Recovery Diagnostics
+    description: Enduring ability to diagnose initialization and traceability drift before recovery work begins
+    current_increment: v1-diagnostics
+    increments:
+      - version: v1-diagnostics
+        phase: opencode-integration
+        number: 3
+        status: delivered
+        follow_up: "#52"
+        use_cases:
+          - recover_from_drift
 validation_rules:
   scenario_phase_must_match_use_case_phase: true
   use_case_phase_must_match_roadmap_phase: true
@@ -369,6 +390,6 @@ backlog_journeys:
     follow_up: "#52"
     reason: Doctor/health recovery and orchestration implementation are deferred.
   - id: recover-from-drift
-    status: future
+    status: partial
     follow_up: "#52"
-    reason: Recovery scenarios and commands are deferred to the diagnostics slice.
+    reason: Doctor/health diagnostics are delivered through recover_from_drift; broader recovery automation remains future work.

--- a/specs/use-cases/recover_from_drift.yml
+++ b/specs/use-cases/recover_from_drift.yml
@@ -1,0 +1,13 @@
+id: recover_from_drift
+name: Recover from Drift
+summary: Detect UDD initialization and traceability drift before remediation work begins
+phase: 3
+actors:
+  - developer
+  - agent
+outcomes:
+  - description: Developers and agents can diagnose initialized, partial, and drifted projects without applying fixes
+    scenarios:
+      - diagnose_project_health
+    scenario_paths:
+      - udd/recovery/diagnose_project_health

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { analyzeProjectDiagnostics } from "../lib/diagnostics.js";
+
+export const doctorCommand = new Command("doctor")
+	.description("Diagnose UDD project health and drift")
+	.option("--json", "Output diagnostics as JSON")
+	.option("--strict", "Exit with code 1 when any issue is detected")
+	.action(async (options) => {
+		const report = await analyzeProjectDiagnostics();
+
+		if (options.json) {
+			console.log(JSON.stringify(report, null, 2));
+		} else {
+			console.log(chalk.bold("UDD Doctor"));
+			console.log(chalk.dim("=========="));
+			console.log("");
+
+			if (report.healthy) {
+				console.log(chalk.green("Project is healthy"));
+			} else {
+				console.log(chalk.yellow(`Found ${report.summary.total} issue(s)`));
+				console.log(
+					chalk.dim(
+						`Critical: ${report.summary.critical}  Warning: ${report.summary.warning}  Info: ${report.summary.info}`,
+					),
+				);
+				console.log("");
+
+				for (const issue of report.issues) {
+					const color =
+						issue.severity === "critical"
+							? chalk.red
+							: issue.severity === "warning"
+								? chalk.yellow
+								: chalk.blue;
+					console.log(color(`${issue.severity.toUpperCase()} ${issue.type}`));
+					console.log(`  ${issue.message}`);
+					console.log(chalk.dim(`  File: ${issue.file}`));
+					console.log(chalk.dim(`  Next: ${issue.recommendation}`));
+				}
+			}
+		}
+
+		if (options.strict && !report.healthy) {
+			process.exitCode = 1;
+		}
+	});

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,0 +1,33 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { analyzeProjectDiagnostics } from "../lib/diagnostics.js";
+
+export const healthCommand = new Command("health-check")
+	.description("Check UDD project health")
+	.option("--json", "Output health status as JSON")
+	.action(async (options) => {
+		const report = await analyzeProjectDiagnostics();
+		const payload = {
+			healthy: report.healthy,
+			status: report.status,
+			summary: report.summary,
+			issues: report.issues,
+			lastCheck: report.lastCheck,
+		};
+
+		if (options.json) {
+			console.log(JSON.stringify(payload, null, 2));
+		} else if (report.healthy) {
+			console.log(chalk.green("Project is healthy"));
+		} else {
+			console.log(chalk.yellow("Project has health issues"));
+			console.log(
+				chalk.dim(
+					`Critical: ${report.summary.critical}  Warning: ${report.summary.warning}  Info: ${report.summary.info}`,
+				),
+			);
+			console.log(chalk.dim("Run 'udd doctor' for details."));
+		}
+
+		process.exitCode = report.healthy ? 0 : 1;
+	});

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -41,15 +41,13 @@ export interface DiagnosticReport {
 	issues: DiagnosticIssue[];
 }
 
-interface ManifestJourney {
-	path?: string;
-	hash?: string;
-	scenarios?: unknown;
+interface Manifest {
+	journeys?: Record<string, unknown>;
+	scenarios?: Record<string, unknown>;
 }
 
-interface Manifest {
-	journeys?: Record<string, ManifestJourney>;
-	scenarios?: Record<string, unknown>;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function hashContent(content: string): string {
@@ -95,7 +93,7 @@ async function readManifest(
 	try {
 		const content = await fs.readFile(manifestPath, "utf-8");
 		const parsed = yaml.parse(content);
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		if (!isRecord(parsed)) {
 			issues.push(
 				issue(
 					"manifest_invalid",
@@ -109,17 +107,26 @@ async function readManifest(
 		}
 
 		const manifest = parsed as Manifest;
-		if (
-			manifest.journeys !== undefined &&
-			(typeof manifest.journeys !== "object" ||
-				Array.isArray(manifest.journeys))
-		) {
+		if (manifest.journeys !== undefined && !isRecord(manifest.journeys)) {
 			issues.push(
 				issue(
 					"manifest_invalid",
 					"critical",
 					"specs/.udd/manifest.yml",
 					"Manifest journeys must be a mapping.",
+					"Run 'udd sync' after checking the manifest file.",
+				),
+			);
+			return null;
+		}
+
+		if (manifest.scenarios !== undefined && !isRecord(manifest.scenarios)) {
+			issues.push(
+				issue(
+					"manifest_invalid",
+					"critical",
+					"specs/.udd/manifest.yml",
+					"Manifest scenarios must be a mapping.",
 					"Run 'udd sync' after checking the manifest file.",
 				),
 			);
@@ -164,7 +171,9 @@ function extractJourneyScenarioPaths(content: string): string[] {
 			continue;
 		}
 
-		const unquoted = line.match(/(?:→|->)\s*(specs\/[^\s]+)/);
+		const unquoted = line.match(
+			/(?:→|->)\s*(specs\/[a-zA-Z0-9_\-./]+?\.feature)\b/,
+		);
 		if (unquoted?.[1]) {
 			paths.add(unquoted[1]);
 		}
@@ -183,7 +192,7 @@ async function inspectJourneys(
 
 	for (const [key, entry] of Object.entries(manifestJourneys)) {
 		const manifestJourneyPath =
-			typeof entry.path === "string"
+			isRecord(entry) && typeof entry.path === "string"
 				? entry.path
 				: posixPath("product", "journeys", `${key}.md`);
 		if (!(await exists(path.join(rootDir, manifestJourneyPath)))) {
@@ -238,7 +247,11 @@ async function inspectJourneys(
 		const key = path.basename(file, ".md");
 		const manifestEntry = manifest?.journeys?.[key];
 
-		if (manifestEntry?.hash && manifestEntry.hash !== hash) {
+		if (
+			isRecord(manifestEntry) &&
+			typeof manifestEntry.hash === "string" &&
+			manifestEntry.hash !== hash
+		) {
 			issues.push(
 				issue(
 					"journey_stale",

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -1,0 +1,387 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { glob } from "glob";
+import yaml from "yaml";
+
+export type DiagnosticSeverity = "critical" | "warning" | "info";
+
+export type DiagnosticIssueType =
+	| "product_missing"
+	| "specs_missing"
+	| "manifest_missing"
+	| "manifest_invalid"
+	| "journeys_missing"
+	| "missing_journey"
+	| "journey_stale"
+	| "missing_scenario"
+	| "orphan_scenario";
+
+export interface DiagnosticIssue {
+	id: string;
+	severity: DiagnosticSeverity;
+	type: DiagnosticIssueType;
+	file: string;
+	message: string;
+	recommendation: string;
+}
+
+export interface DiagnosticSummary {
+	critical: number;
+	warning: number;
+	info: number;
+	total: number;
+}
+
+export interface DiagnosticReport {
+	status: "healthy" | "drift-detected";
+	healthy: boolean;
+	lastCheck: string;
+	summary: DiagnosticSummary;
+	issues: DiagnosticIssue[];
+}
+
+interface ManifestJourney {
+	path?: string;
+	hash?: string;
+	scenarios?: unknown;
+}
+
+interface Manifest {
+	journeys?: Record<string, ManifestJourney>;
+	scenarios?: Record<string, unknown>;
+}
+
+function hashContent(content: string): string {
+	return crypto.createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+function posixPath(...parts: string[]): string {
+	return parts.join("/").replace(/\\/g, "/");
+}
+
+function issue(
+	type: DiagnosticIssueType,
+	severity: DiagnosticSeverity,
+	file: string,
+	message: string,
+	recommendation: string,
+): DiagnosticIssue {
+	return {
+		id: `${severity}:${type}:${file}`,
+		severity,
+		type,
+		file,
+		message,
+		recommendation,
+	};
+}
+
+async function exists(filePath: string): Promise<boolean> {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function readManifest(
+	rootDir: string,
+	issues: DiagnosticIssue[],
+): Promise<Manifest | null> {
+	const manifestPath = path.join(rootDir, "specs", ".udd", "manifest.yml");
+
+	try {
+		const content = await fs.readFile(manifestPath, "utf-8");
+		const parsed = yaml.parse(content);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			issues.push(
+				issue(
+					"manifest_invalid",
+					"critical",
+					"specs/.udd/manifest.yml",
+					"Manifest is not a YAML mapping.",
+					"Run 'udd sync' after checking the manifest file.",
+				),
+			);
+			return null;
+		}
+
+		const manifest = parsed as Manifest;
+		if (
+			manifest.journeys !== undefined &&
+			(typeof manifest.journeys !== "object" ||
+				Array.isArray(manifest.journeys))
+		) {
+			issues.push(
+				issue(
+					"manifest_invalid",
+					"critical",
+					"specs/.udd/manifest.yml",
+					"Manifest journeys must be a mapping.",
+					"Run 'udd sync' after checking the manifest file.",
+				),
+			);
+			return null;
+		}
+
+		return manifest;
+	} catch (error) {
+		if (await exists(manifestPath)) {
+			const message = error instanceof Error ? error.message : String(error);
+			issues.push(
+				issue(
+					"manifest_invalid",
+					"critical",
+					"specs/.udd/manifest.yml",
+					`Manifest could not be parsed: ${message}`,
+					"Fix the YAML or run 'udd sync' to regenerate it.",
+				),
+			);
+			return null;
+		}
+
+		issues.push(
+			issue(
+				"manifest_missing",
+				"critical",
+				"specs/.udd/manifest.yml",
+				"Manifest file is missing.",
+				"Run 'udd init' or 'udd sync' to create the manifest.",
+			),
+		);
+		return null;
+	}
+}
+
+function extractJourneyScenarioPaths(content: string): string[] {
+	const paths = new Set<string>();
+	for (const line of content.split("\n")) {
+		const linked = line.match(/(?:→|->)\s*`([^`]+)`/);
+		if (linked?.[1]) {
+			paths.add(linked[1]);
+			continue;
+		}
+
+		const unquoted = line.match(/(?:→|->)\s*(specs\/[^\s]+)/);
+		if (unquoted?.[1]) {
+			paths.add(unquoted[1]);
+		}
+	}
+	return [...paths];
+}
+
+async function inspectJourneys(
+	rootDir: string,
+	manifest: Manifest | null,
+	issues: DiagnosticIssue[],
+): Promise<Set<string>> {
+	const referencedScenarios = new Set<string>();
+	const journeysDir = path.join(rootDir, "product", "journeys");
+	const manifestJourneys = manifest?.journeys ?? {};
+
+	for (const [key, entry] of Object.entries(manifestJourneys)) {
+		const manifestJourneyPath =
+			typeof entry.path === "string"
+				? entry.path
+				: posixPath("product", "journeys", `${key}.md`);
+		if (!(await exists(path.join(rootDir, manifestJourneyPath)))) {
+			issues.push(
+				issue(
+					"missing_journey",
+					"warning",
+					manifestJourneyPath,
+					`Manifest references missing journey '${key}'.`,
+					"Restore the journey file or run 'udd sync' to refresh the manifest.",
+				),
+			);
+		}
+	}
+
+	for (const scenarioPath of Object.keys(manifest?.scenarios ?? {})) {
+		if (!(await exists(path.join(rootDir, scenarioPath)))) {
+			issues.push(
+				issue(
+					"missing_scenario",
+					"warning",
+					scenarioPath,
+					"Manifest references a missing scenario.",
+					"Restore the scenario file or run 'udd sync' to refresh the manifest.",
+				),
+			);
+		}
+	}
+
+	if (!(await exists(journeysDir))) {
+		issues.push(
+			issue(
+				"journeys_missing",
+				"warning",
+				"product/journeys",
+				"Journey directory is missing.",
+				"Create product journeys or run 'udd init' to restore the structure.",
+			),
+		);
+		return referencedScenarios;
+	}
+
+	const journeyFiles = (await fs.readdir(journeysDir)).filter(
+		(file) => file.endsWith(".md") && !file.startsWith("_"),
+	);
+
+	for (const file of journeyFiles) {
+		const journeyPath = path.join(journeysDir, file);
+		const relJourneyPath = posixPath("product", "journeys", file);
+		const content = await fs.readFile(journeyPath, "utf-8");
+		const hash = hashContent(content);
+		const key = path.basename(file, ".md");
+		const manifestEntry = manifest?.journeys?.[key];
+
+		if (manifestEntry?.hash && manifestEntry.hash !== hash) {
+			issues.push(
+				issue(
+					"journey_stale",
+					"warning",
+					relJourneyPath,
+					`Journey '${key}' has changed since the manifest was written.`,
+					"Run 'udd sync' after reviewing the journey changes.",
+				),
+			);
+		}
+
+		for (const scenarioPath of extractJourneyScenarioPaths(content)) {
+			if (!scenarioPath.startsWith("specs/")) {
+				continue;
+			}
+
+			referencedScenarios.add(
+				scenarioPath
+					.replace(/^specs\/features\//, "")
+					.replace(/\.feature$/, ""),
+			);
+
+			if (!(await exists(path.join(rootDir, scenarioPath)))) {
+				issues.push(
+					issue(
+						"missing_scenario",
+						"warning",
+						scenarioPath,
+						`Journey '${key}' references a missing scenario.`,
+						"Create the scenario or update the journey reference.",
+					),
+				);
+			}
+		}
+	}
+
+	return referencedScenarios;
+}
+
+async function inspectOrphanScenarios(
+	rootDir: string,
+	referencedScenarios: Set<string>,
+	issues: DiagnosticIssue[],
+): Promise<void> {
+	const scenarioFiles = await glob("specs/features/**/*.feature", {
+		cwd: rootDir,
+	});
+
+	const useCaseFiles = await glob("specs/use-cases/*.yml", { cwd: rootDir });
+	for (const file of useCaseFiles) {
+		try {
+			const parsed = yaml.parse(
+				await fs.readFile(path.join(rootDir, file), "utf-8"),
+			);
+			const outcomes = Array.isArray(parsed?.outcomes) ? parsed.outcomes : [];
+			for (const outcome of outcomes) {
+				const scenarioPaths =
+					outcome?.scenario_paths ?? outcome?.scenarios ?? [];
+				if (Array.isArray(scenarioPaths)) {
+					for (const scenarioPath of scenarioPaths) {
+						if (typeof scenarioPath === "string") {
+							referencedScenarios.add(scenarioPath);
+						}
+					}
+				}
+			}
+		} catch {
+			// Invalid use cases are reported by lint; doctor stays focused here.
+		}
+	}
+
+	for (const file of scenarioFiles) {
+		const scenarioId = file
+			.replace(/^specs\/features\//, "")
+			.replace(/\.feature$/, "");
+		if (!referencedScenarios.has(scenarioId)) {
+			issues.push(
+				issue(
+					"orphan_scenario",
+					"warning",
+					file,
+					"Scenario is not referenced by a journey or use case outcome.",
+					"Link the scenario to a use case outcome or remove it.",
+				),
+			);
+		}
+	}
+}
+
+export async function analyzeProjectDiagnostics(
+	rootDir = process.cwd(),
+): Promise<DiagnosticReport> {
+	const issues: DiagnosticIssue[] = [];
+	const productExists = await exists(path.join(rootDir, "product"));
+	const specsExists = await exists(path.join(rootDir, "specs"));
+
+	if (!productExists) {
+		issues.push(
+			issue(
+				"product_missing",
+				"critical",
+				"product",
+				"Product directory is missing.",
+				"Run 'udd init' to create product discovery files.",
+			),
+		);
+	}
+
+	if (!specsExists) {
+		issues.push(
+			issue(
+				"specs_missing",
+				"critical",
+				"specs",
+				"Specs directory is missing.",
+				"Run 'udd init' to create specs/.udd and add scenarios.",
+			),
+		);
+	}
+
+	const manifest = specsExists ? await readManifest(rootDir, issues) : null;
+	let referencedScenarios = new Set<string>();
+
+	if (productExists) {
+		referencedScenarios = await inspectJourneys(rootDir, manifest, issues);
+	}
+
+	if (specsExists) {
+		await inspectOrphanScenarios(rootDir, referencedScenarios, issues);
+	}
+
+	const summary: DiagnosticSummary = {
+		critical: issues.filter((item) => item.severity === "critical").length,
+		warning: issues.filter((item) => item.severity === "warning").length,
+		info: issues.filter((item) => item.severity === "info").length,
+		total: issues.length,
+	};
+
+	return {
+		status: issues.length === 0 ? "healthy" : "drift-detected",
+		healthy: issues.length === 0,
+		lastCheck: new Date().toISOString(),
+		summary,
+		issues,
+	};
+}

--- a/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
+++ b/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
@@ -253,4 +253,144 @@ describeFeature(feature, ({ Scenario }) => {
 			);
 		},
 	);
+
+	Scenario(
+		"Report malformed manifest diagnostics",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with manifest scenarios stored as a list",
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "product/journeys"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						"journeys: {}\nscenarios: []\n",
+					);
+				},
+			);
+
+			When('I run "udd doctor --json"', async () => {
+				output = await runUddInProject("doctor --json");
+			});
+
+			Then(
+				'the JSON report should identify the project as "drift-detected"',
+				() => {
+					const report = parsedJson<{ status: string }>();
+					expect(report.status).toBe("drift-detected");
+				},
+			);
+
+			And('the report should include a "manifest_invalid" issue', async () => {
+				try {
+					expect(issueTypes(parsedJson())).toContain("manifest_invalid");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Report null journey manifest entries without crashing",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with a null journey manifest entry",
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "product/journeys"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						"journeys:\n  missing: null\nscenarios: {}\n",
+					);
+				},
+			);
+
+			When('I run "udd health-check --json"', async () => {
+				output = await runUddInProject("health-check --json");
+			});
+
+			Then("the JSON health report should be unhealthy", () => {
+				const report = parsedJson<{ healthy: boolean }>();
+				expect(report.healthy).toBe(false);
+			});
+
+			And('the report should include a "missing_journey" issue', async () => {
+				try {
+					expect(issueTypes(parsedJson())).toContain("missing_journey");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Ignore punctuation after unquoted journey scenario paths",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with an unquoted journey scenario path followed by punctuation",
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "product/journeys"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/features/punctuation"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "product/journeys/punctuation.md"),
+						[
+							"# Journey: Punctuation",
+							"",
+							"1. Check punctuation -> specs/features/punctuation/check.feature.",
+							"",
+						].join("\n"),
+					);
+					await fs.writeFile(
+						path.join(projectDir, "specs/features/punctuation/check.feature"),
+						"Feature: Check\n\n  Scenario: Check punctuation\n    Given punctuation exists\n",
+					);
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						"journeys: {}\nscenarios: {}\n",
+					);
+				},
+			);
+
+			When('I run "udd doctor --json"', async () => {
+				output = await runUddInProject("doctor --json");
+			});
+
+			Then('the JSON report should identify the project as "healthy"', () => {
+				const report = parsedJson<{ status: string; healthy: boolean }>();
+				expect(report.status).toBe("healthy");
+				expect(report.healthy).toBe(true);
+			});
+
+			And(
+				'the report should not include a "missing_scenario" issue',
+				async () => {
+					try {
+						expect(issueTypes(parsedJson())).not.toContain("missing_scenario");
+					} finally {
+						await cleanupProject();
+					}
+				},
+			);
+		},
+	);
 });

--- a/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
+++ b/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import { buildUddCommand, execAsync } from "../../../utils.js";
+
+const feature = await loadFeature(
+	"specs/features/udd/recovery/diagnose_project_health.feature",
+);
+
+interface CommandResult {
+	stdout: string;
+	stderr: string;
+	code?: number;
+}
+
+let previousCwd: string;
+let projectDir: string;
+let output: CommandResult;
+
+async function cleanupProject() {
+	if (!projectDir) return;
+	process.chdir(previousCwd);
+	await fs.rm(projectDir, { recursive: true, force: true });
+	projectDir = "";
+}
+
+async function startProject() {
+	await cleanupProject();
+	previousCwd = process.cwd();
+	projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "udd-doctor-e2e-"));
+	process.chdir(projectDir);
+}
+
+async function runUddInProject(args: string): Promise<CommandResult> {
+	try {
+		return await execAsync(buildUddCommand(args));
+	} catch (error: unknown) {
+		return error as CommandResult;
+	}
+}
+
+function parsedJson<T extends Record<string, unknown>>(): T {
+	return JSON.parse(output.stdout) as T;
+}
+
+function issueTypes(report: Record<string, unknown>): string[] {
+	const issues = report.issues;
+	expect(Array.isArray(issues)).toBe(true);
+	return (issues as Array<{ type: string }>).map((issue) => issue.type);
+}
+
+describeFeature(feature, ({ Scenario }) => {
+	Scenario(
+		"Report real initialized project diagnostics",
+		({ Given, When, Then, And }) => {
+			Given(
+				'a temporary project initialized with "udd init --yes"',
+				async () => {
+					await startProject();
+					const init = await runUddInProject("init --yes");
+					expect(init.stdout).toContain("UDD initialized");
+				},
+			);
+
+			When('I run "udd doctor --json"', async () => {
+				output = await runUddInProject("doctor --json");
+			});
+
+			Then(
+				'the JSON report should identify the project as "drift-detected"',
+				() => {
+					const report = parsedJson<{ status: string; healthy: boolean }>();
+					expect(report.status).toBe("drift-detected");
+					expect(report.healthy).toBe(false);
+				},
+			);
+
+			And('the report should include a "missing_scenario" issue', async () => {
+				try {
+					expect(issueTypes(parsedJson())).toContain("missing_scenario");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Report partial initialization diagnostics",
+		({ Given, When, Then, And }) => {
+			Given(
+				'a temporary project with "specs/.udd" but no "product" directory',
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						"journeys: {}\nscenarios: {}\n",
+					);
+				},
+			);
+
+			When('I run "udd health-check --json"', async () => {
+				output = await runUddInProject("health-check --json");
+			});
+
+			Then("the JSON health report should be unhealthy", () => {
+				const report = parsedJson<{ healthy: boolean; status: string }>();
+				expect(report.healthy).toBe(false);
+				expect(report.status).toBe("drift-detected");
+			});
+
+			And('the report should include a "product_missing" issue', async () => {
+				try {
+					expect(issueTypes(parsedJson())).toContain("product_missing");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Report drifted journey diagnostics",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with a stale journey manifest entry",
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "product/journeys"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/features/drift"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "product/journeys/drift.md"),
+						[
+							"# Journey: Drift",
+							"",
+							"**Actor:** User",
+							"**Goal:** Detect drift",
+							"",
+							"## Steps",
+							"",
+							"1. Detect stale journey -> `specs/features/drift/check.feature`",
+							"",
+						].join("\n"),
+					);
+					await fs.writeFile(
+						path.join(projectDir, "specs/features/drift/check.feature"),
+						"Feature: Check\n\n  Scenario: Check drift\n    Given drift exists\n",
+					);
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						[
+							"journeys:",
+							"  drift:",
+							"    path: product/journeys/drift.md",
+							"    hash: old-hash",
+							"    scenarios:",
+							"      - specs/features/drift/check.feature",
+							"scenarios: {}",
+							"",
+						].join("\n"),
+					);
+				},
+			);
+
+			When('I run "udd doctor --json"', async () => {
+				output = await runUddInProject("doctor --json");
+			});
+
+			Then(
+				'the JSON report should identify the project as "drift-detected"',
+				() => {
+					const report = parsedJson<{ status: string }>();
+					expect(report.status).toBe("drift-detected");
+				},
+			);
+
+			And('the report should include a "journey_stale" issue', async () => {
+				try {
+					expect(issueTypes(parsedJson())).toContain("journey_stale");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Report deleted files still referenced by the manifest",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with manifest entries for deleted journey and scenario files",
+				async () => {
+					await startProject();
+					await fs.mkdir(path.join(projectDir, "product/journeys"), {
+						recursive: true,
+					});
+					await fs.mkdir(path.join(projectDir, "specs/.udd"), {
+						recursive: true,
+					});
+					await fs.writeFile(
+						path.join(projectDir, "specs/.udd/manifest.yml"),
+						[
+							"journeys:",
+							"  deleted:",
+							"    path: product/journeys/deleted.md",
+							"    hash: deleted-hash",
+							"    scenarios:",
+							"      - specs/features/deleted/path.feature",
+							"scenarios:",
+							"  specs/features/deleted/path.feature:",
+							"    hash: deleted-scenario-hash",
+							"    test: tests/e2e/deleted/path.e2e.test.ts",
+							"    status: pending",
+							"",
+						].join("\n"),
+					);
+				},
+			);
+
+			When('I run "udd health-check --json"', async () => {
+				output = await runUddInProject("health-check --json");
+			});
+
+			Then("the JSON health report should be unhealthy", () => {
+				const report = parsedJson<{ healthy: boolean; status: string }>();
+				expect(report.healthy).toBe(false);
+				expect(report.status).toBe("drift-detected");
+			});
+
+			And(
+				'the report should include "missing_journey" and "missing_scenario" issues',
+				async () => {
+					try {
+						const types = issueTypes(parsedJson());
+						expect(types).toContain("missing_journey");
+						expect(types).toContain("missing_scenario");
+					} finally {
+						await cleanupProject();
+					}
+				},
+			);
+		},
+	);
+});


### PR DESCRIPTION
## Summary
- Adds a focused, read-only diagnostics slice for issue #52: `udd doctor` and `udd health-check`.
- Wires the slice through UDD specs first with a recovery use case, feature file, and roadmap capability entry.
- Detects initialized, partially initialized, and drifted project states including missing product/specs structure, invalid manifests, stale journey hashes, missing manifest files, missing scenario references, missing manifest-referenced files, and orphan scenarios.

Closes #52.

## Scope Guard
This intentionally does not include broad PR #45 recovery orchestration, auto-fix behavior, hook installation, or unrelated test governance. PR #45 was verified as closed/superseded, and the audit report scoped this work to the doctor and health diagnostics slice.

## Review Follow-Up
- Independent Codex review found a manifest-only drift gap where deleted journey/scenario files referenced by `specs/.udd/manifest.yml` were not reported. Fixed before PR creation with regression coverage.
- Gemini review found robustness gaps for null journey manifest entries, non-mapping `manifest.scenarios`, and unquoted journey scenario paths followed by punctuation. Fixed in commit `5238403` with spec and E2E coverage.

## Verification
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd lint`
- `PATH="$HOME/.bun/bin:$PATH" UDD_TEST_RUNTIME=bun ./bin/udd test` — 38 files, 322 tests passed
- `PATH="$HOME/.bun/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="$HOME/.bun/bin:$PATH" ./node_modules/.bin/biome check bin/udd.ts src/lib/diagnostics.ts src/commands/doctor.ts src/commands/health.ts tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd validate --feature specs/features/udd/recovery/diagnose_project_health.feature --strict`
- `rg -n "\b(skip|todo|stub)\b|\.skip\(|\.todo\(" specs/features/udd/recovery/diagnose_project_health.feature tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts src/lib/diagnostics.ts src/commands/doctor.ts src/commands/health.ts` — no matches

## Baseline Notes
- Branch was created from current `origin/master` at `67bbffd`.
- `gh` was not installed in this shell, so GitHub connector was used for issue, PR, and review operations.
- Codex environment had `node` but not `npm`/`npx`; `scripts/codex-setup.sh` was run and checks used the Bun-backed PATH per `AGENTS.md`.