### PR TITLE
docs: salvage architecture and process guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# UDD Architecture
+
+UDD is a spec-first CLI and workflow for keeping user intent, behavior
+contracts, and verification aligned. The current repository state is a
+compatibility-mode architecture: user-facing scenarios remain the behavior
+contract, while journey and SysML-informed material provide discovery context
+when they improve the scenario.
+
+This document is the stable overview. Detailed guidance lives in scoped docs:
+
+- `docs/architecture/canonical-derivation-model.md`
+- `docs/architecture/concept-mappings.md`
+- `docs/process/recovery-workflow.md`
+- `docs/testing/troubleshooting-stubs.md`
+
+## Current Source-Of-Truth Layers
+
+| Layer | Current artifact | Purpose |
+| --- | --- | --- |
+| Stable product purpose | `specs/VISION.md` | Long-term goals, success metrics, and state boundaries |
+| Planning objective | `specs/roadmap.yml`, `goals/*.md`, GitHub issues | Current phase, capability increments, and scoped work |
+| Optional discovery context | `product/journeys/*.md`, `docs/sysml-informed-discovery.md` | User context, alternatives considered, and workflow narrative |
+| Required behavior contract | `specs/use-cases/*.yml` and `specs/features/**/*.feature` | Use-case outcomes and scenario files that describe observable behavior |
+| Executable proof | `tests/e2e/**/*.test.ts` | Tests that prove the scenario behavior is true now |
+| CLI state inspection | `udd status`, `udd lint`, `udd phase`, `udd doctor`, `udd health-check` | Readable and machine-readable views of traceability and drift |
+
+The canonical behavior chain for current work is:
+
+```text
+Objective -> Use Case -> Scenario -> E2E Test
+```
+
+Journey files are useful discovery artifacts, and this repository dogfoods them,
+but they should not become a duplicate requirement layer. If a journey changes
+behavior, update the use case or scenario before implementation.
+
+## Current CLI Behavior
+
+The current `master` branch includes these architecture-relevant commands:
+
+- `udd status`: summarizes use-case, scenario, test, roadmap, and git state.
+- `udd lint`: validates spec structure and relationships.
+- `udd phase current/list/set/check`: reads and validates phase state from
+  `specs/roadmap.yml`.
+- `udd doctor`: reports initialized, partial, and drifted project states. It
+  supports `--json` and `--strict`; it does not apply fixes.
+- `udd health-check`: returns health status for automation. It supports `--json`.
+- `udd sync`: updates journey-driven scenario state when journey files drive the
+  change.
+
+## Current Versus Future Architecture
+
+| Topic | Current behavior | Future architecture |
+| --- | --- | --- |
+| Phase source of truth | `specs/roadmap.yml` drives `udd phase` commands. | Richer phase-aware planning can build on the same roadmap file. |
+| Traceability contract | Use cases link outcomes to scenario paths; tests prove the scenarios. | Components, requirements, and test-review artifacts can extend the graph when implementation ownership needs stronger validation. |
+| Recovery | `udd doctor` and `udd health-check` diagnose drift without mutating files. | Automated or checkpoint-based recovery belongs in a later implementation slice. |
+| Test governance | Meaningful assertions are expected by review and local search. | Automated stub detection and enforcement are planned under the test-governance follow-up. |
+| Agent integrations | Shared behavior should route through UDD status, phase, and traceability commands. | Adapter-specific tooling should remain installable integration code, not root-local state. |
+
+## Change Workflow
+
+1. Start with `udd status`.
+2. Identify the objective in `specs/roadmap.yml`, a goal file, or the GitHub
+   issue.
+3. Update the use case or scenario before implementation.
+4. Run `udd sync` only when journey files are the driver for scenario changes.
+5. Implement until the E2E proof passes.
+6. Run the relevant checks: `udd lint`, targeted tests, `udd phase check`, and
+   diagnostics when the change can affect drift.
+
+This keeps the repository aligned with the rule that behavior is specified
+before it is implemented.

--- a/docs/architecture/canonical-derivation-model.md
+++ b/docs/architecture/canonical-derivation-model.md
@@ -26,9 +26,15 @@ Objectives answer:
 ### Use Case
 
 Use cases live in `specs/use-cases/*.yml`. They group user-visible outcomes and
-link those outcomes to canonical scenario paths.
+link those outcomes to canonical scenario ids and paths.
 
-The current CLI compatibility layer reads use-case outcomes and
+Keep scenario ids separate from file paths across specification files. Store
+canonical ids under `scenarios` and concrete feature-file paths under
+`scenario_paths`. This convention applies anywhere the docs or specs need both
+the stable behavior id and the file lookup path, including roadmap, use-case,
+and requirement artifacts.
+
+The current CLI compatibility layer reads use-case outcomes, `scenarios`, and
 `scenario_paths` to build status and traceability views.
 
 ### Scenario
@@ -51,6 +57,10 @@ Journey files in `product/journeys/*.md` and SysML-informed notes help authors
 ask better product questions. They are valuable context, but they should not
 duplicate the required behavior contract. When a journey changes behavior, the
 author must update the use case or scenario that carries the contract.
+
+Do not hardcode broad journey or use-case classification lists in journey
+markdown. Use `specs/roadmap.yml` as the classification source of truth and
+distinguish current use cases, future use cases, and backlog journeys there.
 
 Current diagnostics can report stale journey mappings and missing scenario
 references, because this repository dogfoods journey-driven discovery. That is a

--- a/docs/architecture/canonical-derivation-model.md
+++ b/docs/architecture/canonical-derivation-model.md
@@ -1,0 +1,89 @@
+# Canonical Derivation Model
+
+This document defines the current derivation chain for UDD work and separates
+the enforced model from future traceability extensions.
+
+## Current Chain
+
+```text
+Objective -> Use Case -> Scenario -> E2E Test
+```
+
+## Layer Definitions
+
+### Objective
+
+An objective is the reason for the work. In this repository it normally appears
+as a GitHub issue, `goals/*.md`, or a capability increment in
+`specs/roadmap.yml`.
+
+Objectives answer:
+
+- Why does this change matter?
+- Which capability or phase owns it?
+- What proof will show it is complete?
+
+### Use Case
+
+Use cases live in `specs/use-cases/*.yml`. They group user-visible outcomes and
+link those outcomes to canonical scenario paths.
+
+The current CLI compatibility layer reads use-case outcomes and
+`scenario_paths` to build status and traceability views.
+
+### Scenario
+
+Scenarios live in `specs/features/**/*.feature`. They are the behavior contract.
+They should describe observable behavior from the user or agent perspective, not
+internal implementation steps.
+
+Phase tags such as `@phase:3` are read by phase validation. Future-phase
+scenarios are planning context until the roadmap makes that phase current.
+
+### E2E Test
+
+E2E tests live in `tests/e2e/**/*.test.ts`. They are the executable proof for a
+scenario. A test should fail when the scenario behavior is not true.
+
+## Optional Discovery Context
+
+Journey files in `product/journeys/*.md` and SysML-informed notes help authors
+ask better product questions. They are valuable context, but they should not
+duplicate the required behavior contract. When a journey changes behavior, the
+author must update the use case or scenario that carries the contract.
+
+Current diagnostics can report stale journey mappings and missing scenario
+references, because this repository dogfoods journey-driven discovery. That is a
+drift signal, not a license to skip the use-case and scenario layer.
+
+## Future Traceability Extensions
+
+`specs/traceability-contract.yml` defines a broader graph that can support
+personas, journeys, components, requirements, and test reviews. Those concepts
+are useful when implementation ownership or impact analysis needs more detail.
+
+They should be added only when the focused slice also includes the behavior,
+validation, and tests that make the new artifact authoritative.
+
+## Anti-Patterns
+
+- Implementing code from a journey note without updating the use case or
+  scenario.
+- Adding requirements, components, or review artifacts without a validation path.
+- Treating generated state under `specs/.udd/` as hand-authored product intent.
+- Re-importing stale side-branch files that describe commands not present on
+  current `master`.
+
+## Verification Commands
+
+Use these commands to inspect the current chain:
+
+```bash
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd status
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd lint
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd phase check
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd doctor --json
+```
+
+`udd doctor --strict` and `udd health-check --json` intentionally return
+non-zero when they find drift.

--- a/docs/architecture/concept-mappings.md
+++ b/docs/architecture/concept-mappings.md
@@ -76,7 +76,8 @@ Use component or requirement artifacts when:
 
 ## Naming Guidance
 
-- Use stable snake_case ids for use cases.
+- Use stable snake_case ids for use cases and personas.
+- Keep journey ids in kebab-case to match existing journey filenames.
 - Use path-like scenario ids that match feature locations.
 - Keep phase assignment in `specs/roadmap.yml` and scenario `@phase:N` tags.
 - Avoid generic planning names such as story, epic, or ticket in trace fields

--- a/docs/architecture/concept-mappings.md
+++ b/docs/architecture/concept-mappings.md
@@ -1,0 +1,83 @@
+# UDD Concept Mappings
+
+UDD borrows systems-engineering discipline without adding unnecessary artifact
+layers. The mapping below describes how current repository artifacts line up
+with the concepts they represent.
+
+## Current Mapping
+
+| UDD concept | Systems-engineering analogue | Current location | Current status |
+| --- | --- | --- | --- |
+| Vision | System purpose and boundaries | `specs/VISION.md` | Stable source for long-term intent |
+| Objective | Planned work item or capability increment | `specs/roadmap.yml`, `goals/*.md`, GitHub issues | Required for scoped work |
+| Journey | Concept of operations / discovery narrative | `product/journeys/*.md` | Optional context; dogfooded in this repo |
+| Use case | Functional requirement group | `specs/use-cases/*.yml` | Required behavior grouping |
+| Scenario | Acceptance criterion | `specs/features/**/*.feature` | Required behavior contract |
+| E2E test | Verification case | `tests/e2e/**/*.test.ts` | Required executable proof |
+| Component | Implementation ownership surface | `specs/components/*.yml` | Available for focused ownership docs |
+| Requirement | Implementation contract | `specs/requirements/*.yml` | Available, but not required for every slice |
+| Roadmap phase | Life-cycle increment | `specs/roadmap.yml` | Current phase source of truth |
+
+## Process Alignment
+
+```text
+Stakeholder need      -> objective and optional journey context
+User-visible outcome  -> use-case outcome
+Behavior contract     -> Gherkin scenario
+Proof                 -> E2E test
+Implementation owner  -> component or requirement when needed
+```
+
+The thin current path is intentional. Adding a richer graph is useful only when
+it reduces ambiguity for a real change.
+
+## Capability Evolution
+
+Capabilities evolve through `specs/roadmap.yml`. The current active phase is
+`opencode-integration`, displayed by `udd phase current` as phase 3:
+Agent Integration.
+
+Roadmap entries can distinguish:
+
+- `delivered`: behavior is implemented and has an executable proof.
+- `active`: the phase is current.
+- `planned` or `future`: useful architecture context, not current behavior.
+- `follow_up`: the GitHub issue that owns later work.
+
+Docs must preserve that distinction. For example, recovery diagnostics are
+delivered through `udd doctor` and `udd health-check`, while broader recovery
+automation remains future work.
+
+## Decision Rules
+
+Create or update a use case when:
+
+- a user-visible outcome changes,
+- a scenario needs a new canonical home,
+- the roadmap assigns a capability to a different phase or increment.
+
+Create or update a scenario when:
+
+- acceptance behavior changes,
+- edge cases become part of the contract,
+- a test needs a clearer user-observable assertion.
+
+Use a journey when:
+
+- discovery needs actor, context, alternatives, or workflow narrative,
+- SysML-informed questions would improve the scenario,
+- a future capability needs narrative context before it is ready to implement.
+
+Use component or requirement artifacts when:
+
+- implementation ownership is ambiguous,
+- impact analysis needs a durable implementation link,
+- the slice includes validation proving the new link is maintained.
+
+## Naming Guidance
+
+- Use stable snake_case ids for use cases.
+- Use path-like scenario ids that match feature locations.
+- Keep phase assignment in `specs/roadmap.yml` and scenario `@phase:N` tags.
+- Avoid generic planning names such as story, epic, or ticket in trace fields
+  when a UDD concept is more precise.

--- a/docs/process/recovery-workflow.md
+++ b/docs/process/recovery-workflow.md
@@ -1,0 +1,75 @@
+# Recovery Workflow
+
+This document describes the recovery process that is current on `master`.
+Recovery is diagnostic-first: the CLI reports drift and health state, but it
+does not apply automated fixes.
+
+## Current Diagnostic Commands
+
+```bash
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd doctor
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd doctor --json
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd doctor --strict
+PATH="$HOME/.bun/bin:$PATH" ./bin/udd health-check --json
+```
+
+Current command behavior:
+
+- `udd doctor` prints human-readable diagnostic details.
+- `udd doctor --json` emits machine-readable diagnostic details.
+- `udd doctor --strict` exits non-zero when any issue is detected.
+- `udd health-check --json` emits a concise health envelope for automation.
+
+There is no current `udd doctor --fix`, checkpoint resume, or auto-remediation
+command. Those remain future architecture until a focused implementation slice
+adds and verifies them.
+
+## Current Drift Signals
+
+The current diagnostics focus on safe read-only signals, including:
+
+- initialized, partially initialized, or missing UDD project structure,
+- malformed or invalid `specs/.udd/manifest.yml`,
+- stale journey hashes,
+- journey references to missing scenario files,
+- manifest references to missing journey or scenario files,
+- orphan scenarios.
+
+`udd lint` remains the structural spec validator. Recovery diagnostics should be
+read alongside lint and status output rather than treated as a replacement.
+
+## Recovery Process
+
+1. Run `udd status` to understand the project-wide baseline.
+2. Run `udd doctor --json` or `udd health-check --json` to identify drift.
+3. Classify each issue as current-slice work, known baseline debt, or future
+   follow-up.
+4. Fix source artifacts directly:
+   - update stale journey references only when the journey is the source,
+   - update use cases when outcomes or scenario links changed,
+   - update scenarios when behavior changed,
+   - update tests when executable proof is missing or stale.
+5. Run `udd sync` only when journey files intentionally drive scenario updates.
+6. Re-run `udd lint`, targeted tests, `udd status`, and diagnostics relevant to
+   the changed surface.
+
+## Baseline Drift
+
+This repository may intentionally contain future or partial journey references
+while salvage work proceeds. A docs-only PR should not try to resolve that
+baseline unless its objective explicitly includes it.
+
+When diagnostics fail because of known baseline drift, record the command output
+and explain why the failure is pre-existing and outside the slice.
+
+## Future Recovery Architecture
+
+Future work may add:
+
+- interactive fix flows,
+- checkpoint files,
+- auto-remediation for unambiguous stale metadata,
+- move/rename helpers that update references.
+
+Those behaviors must be introduced with use cases, scenarios, tests, and CLI
+documentation in the same implementation slice.

--- a/docs/testing/troubleshooting-stubs.md
+++ b/docs/testing/troubleshooting-stubs.md
@@ -1,0 +1,58 @@
+# Troubleshooting Stub Assertions
+
+Stub assertions are tests that pass without proving behavior. They are harmful
+because they make status output look healthier than the implementation really
+is.
+
+## Common Stub Patterns
+
+| Pattern | Why it is a stub |
+| --- | --- |
+| `expect(true).toBe(true)` | Always true |
+| `expect(1).toBe(1)` | Always true |
+| `expect("ok").toBe("ok")` | Always true |
+| `expect(result).toBe(result)` | Compares a value to itself |
+| `expect(value).toBeDefined()` as the only assertion | Often proves setup, not behavior |
+
+## Current Practice
+
+Automated test-governance enforcement is planned in the roadmap, but it is not
+the current behavior of `udd doctor` or `udd health-check`. Today, stub
+assertions are prevented by author review, independent review, and targeted
+search.
+
+Useful local searches:
+
+```bash
+rg -n "expect\\((true|false|0|1|\"[^\"]*\"|'[^']*')\\)\\.to(Be|Equal|StrictEqual)\\(\\1\\)" tests
+rg -n "\\b(skip|todo|stub)\\b|\\.skip\\(|\\.todo\\(" specs tests src
+```
+
+Treat search results as review leads, not automatic proof. Some matches may be
+legitimate, and some weak assertions do not match a simple pattern.
+
+## Fixing A Stub
+
+1. Read the scenario step and identify the observable behavior.
+2. Make the test fail when that behavior is absent.
+3. Prefer user-visible state, command output, file state, exit code, or persisted
+   data over implementation internals.
+4. Keep the assertion as narrow as the scenario requires.
+
+Example:
+
+```ts
+// Weak: proves only that the test ran.
+expect(true).toBe(true);
+
+// Better: proves the command produced the required result.
+expect(result.exitCode).toBe(0);
+expect(result.stdout).toContain("Project Status");
+```
+
+## Future Enforcement
+
+The roadmap tracks broader test-governance work separately. A future slice can
+make stub detection machine-enforced, phase-aware, and integrated with health
+checks. Until that work lands, docs and PRs should not claim that `udd doctor`
+or `udd health-check` blocks stub assertions.


### PR DESCRIPTION
## Summary
- Salvages the still-current architecture and process guidance from `origin/codex/source-of-truth-cleanup-base` into scoped docs.
- Adds a stable architecture overview plus canonical derivation, concept mapping, recovery diagnostics, and stub-assertion troubleshooting docs.
- Reconciles the docs to current `master` after PR #62 by documenting delivered phase/traceability and doctor/health behavior separately from future architecture.

Closes #50.

## Scope Guard
- Docs-only PR.
- Does not import stale scratch docs, generated state, `.udd/config.yml`, `bun.lock`, local hook state, or unrelated implementation/spec/test changes.
- Does not claim unsupported commands such as `udd doctor --fix`; recovery automation and test-governance enforcement are explicitly framed as future work.

## Review Follow-Up
- Independent Codex review completed before PR creation with no blocking findings.
- Gemini posted three medium-priority docs comments.
- Commit `85ce604` addressed the Gemini comments by documenting `scenarios` vs `scenario_paths`, adding roadmap-as-classification-source guidance for journeys, and clarifying id casing conventions.
- All three Gemini review threads were replied to and resolved.

## Verification
- PR #62 verified merged into `origin/master` at `518318e`; this branch is based on that commit.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd status` - ran; shows known baseline drift and dirty state while docs were uncommitted.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd lint` - passed.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd phase current && PATH="$HOME/.bun/bin:$PATH" ./bin/udd phase list && PATH="$HOME/.bun/bin:$PATH" ./bin/udd phase check` - passed.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd doctor --json` - ran; reports known 54-warning drift baseline with zero critical issues.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd health-check --json` - expected non-zero; reports the same known 54-warning drift baseline.
- `PATH="$HOME/.bun/bin:$PATH" ./bin/udd validate --feature specs/features/udd/recovery/diagnose_project_health.feature --strict` - passed with advisory completeness warnings.
- `PATH="$HOME/.bun/bin:$PATH" ./node_modules/.bin/biome check ARCHITECTURE.md docs/architecture/canonical-derivation-model.md docs/architecture/concept-mappings.md docs/process/recovery-workflow.md docs/testing/troubleshooting-stubs.md` - not applicable; Biome ignored Markdown and processed 0 files.
- GitGuardian Security Checks passed on final head `85ce604`.