### PR TITLE
feat: salvage local test governance gates

### DIFF
--- a/specs/features/udd/test-governance/local-gate-validation.feature
+++ b/specs/features/udd/test-governance/local-gate-validation.feature
@@ -1,0 +1,52 @@
+Feature: Local Test Governance Gate
+
+# User Need:
+#   Developers and agents need a local way to find weak or stale tests before
+#   enabling broader repository gates.
+#
+# Alternatives Considered:
+#   - CI-first enforcement: too broad while the repo still has known baseline drift
+#   - Metrics-only reporting: does not prevent stub tests from creating false confidence
+#   - Pre-commit hooks in this slice: risks blocking unrelated local work too early
+#
+# Success Criteria:
+#   - Test scanning identifies linked, unlinked, orphaned, and stubbed tests
+#   - Test review records stay in local UDD state rather than tracked generated files
+#   - Gate checks are explicit and advisory unless strict mode is requested
+
+  Background:
+    Given a UDD project is initialized
+
+  @phase:3
+  Scenario: Scan tests for governance findings
+    Given the project has linked, unlinked, orphaned, and stubbed tests
+    When I run "udd test scan --json"
+    Then the scan reports linked, unlinked, orphaned, and stubbed counts
+    And the linked test includes its feature path
+
+  @phase:3
+  Scenario: Resolve feature comment references with feature extension
+    Given the project has a test linked by an "@feature" comment ending in ".feature" plus punctuation
+    When I run "udd test scan --json"
+    Then the feature comment test is reported as linked
+
+  @phase:3
+  Scenario: Record a local test review
+    Given the project has a meaningful linked test
+    When I run "udd test review tests/auth/login.e2e.test.ts"
+    Then the test review manifest records the test as clean
+    And "udd test status --json" reports the review record
+
+  @phase:3
+  Scenario: Run an explicit local gate
+    Given the project has dirty local review state
+    When I run "udd test gate"
+    Then the gate reports findings without failing
+    When I run "udd test gate --strict"
+    Then the strict gate fails with the dirty test listed
+
+  @phase:3
+  Scenario: Block strict gates on invalid local review state
+    Given the project has an invalid local review manifest
+    When I run "udd test gate --strict"
+    Then the strict gate fails with the review manifest issue listed

--- a/specs/roadmap.yml
+++ b/specs/roadmap.yml
@@ -154,8 +154,12 @@ phases:
       - id: track_test_quality
         capability: test-governance
         increment: v1-basic
-        status: future
+        status: partial
         follow_up: "#55"
+        scenarios:
+          - local-gate-validation
+        scenario_paths:
+          - udd/test-governance/local-gate-validation
         future_scenarios:
           - health-metrics
           - test-scan
@@ -180,8 +184,12 @@ phases:
       - id: manage_test_lifecycle
         capability: test-governance
         increment: v1-basic
-        status: future
+        status: partial
         follow_up: "#55"
+        scenarios:
+          - local-gate-validation
+        scenario_paths:
+          - udd/test-governance/local-gate-validation
         future_scenarios:
           - test-review
           - hooks-installation
@@ -193,8 +201,12 @@ phases:
       - id: enforce_quality_gates
         capability: test-governance
         increment: v1-basic
-        status: future
+        status: partial
         follow_up: "#55"
+        scenarios:
+          - local-gate-validation
+        scenario_paths:
+          - udd/test-governance/local-gate-validation
         future_scenarios:
           - ci-validation
           - test-approval

--- a/specs/use-cases/enforce_quality_gates.yml
+++ b/specs/use-cases/enforce_quality_gates.yml
@@ -5,6 +5,12 @@ phase: 3
 actors:
   - developer
   - agent
+outcomes:
+  - description: Explicit local test-governance gates report findings and only fail when strict mode is requested
+    scenarios:
+      - local-gate-validation
+    scenario_paths:
+      - udd/test-governance/local-gate-validation
 future_outcomes:
   - description: CI enforces coverage and pass-rate thresholds
     follow_up: "#55"

--- a/specs/use-cases/manage_test_lifecycle.yml
+++ b/specs/use-cases/manage_test_lifecycle.yml
@@ -5,6 +5,12 @@ phase: 3
 actors:
   - developer
   - agent
+outcomes:
+  - description: Reviewed tests can be recorded in local UDD state without committing generated review state
+    scenarios:
+      - local-gate-validation
+    scenario_paths:
+      - udd/test-governance/local-gate-validation
 future_outcomes:
   - description: Tests have lifecycle states (draft, active, deprecated)
     follow_up: "#55"

--- a/specs/use-cases/track_test_quality.yml
+++ b/specs/use-cases/track_test_quality.yml
@@ -5,6 +5,12 @@ phase: 3
 actors:
   - developer
   - agent
+outcomes:
+  - description: Test inventory scans identify linked, unlinked, orphaned, and stubbed tests before gates are enabled
+    scenarios:
+      - local-gate-validation
+    scenario_paths:
+      - udd/test-governance/local-gate-validation
 future_outcomes:
   - description: Test coverage metrics are available
     follow_up: "#55"

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,8 +1,17 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
+import chalk from "chalk";
 import { Command } from "commander";
+import {
+	checkTestGate,
+	loadTestReviewManifest,
+	reviewTest,
+	scanTests,
+} from "../lib/test-governance.js";
 
-export const testCommand = new Command("test")
+export const testCommand = new Command("test");
+
+testCommand
 	.description("Run E2E tests with visual feedback")
 	.argument("[args...]", "Arguments to pass to vitest")
 	.action(async (args) => {
@@ -29,4 +38,159 @@ export const testCommand = new Command("test")
 			console.error(err);
 			process.exit(1);
 		});
+	});
+
+testCommand
+	.command("scan")
+	.description("Scan tests for feature links and stub assertions")
+	.option("--json", "Output scan result as JSON")
+	.action(async (options: { json?: boolean }) => {
+		const entries = await scanTests();
+		const linked = entries.filter((entry) => entry.status === "linked").length;
+		const unlinked = entries.filter(
+			(entry) => entry.status === "unlinked",
+		).length;
+		const orphaned = entries.filter(
+			(entry) => entry.status === "orphaned",
+		).length;
+		const stubbed = entries.filter(
+			(entry) => entry.stubAssertions.length > 0,
+		).length;
+
+		if (options.json) {
+			console.log(
+				JSON.stringify(
+					{
+						summary: {
+							total: entries.length,
+							linked,
+							unlinked,
+							orphaned,
+							stubbed,
+						},
+						tests: entries,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		console.log(chalk.bold("Test Scan"));
+		console.log(chalk.dim("========="));
+		console.log(
+			`Total: ${entries.length}  Linked: ${linked}  Unlinked: ${unlinked}  Orphaned: ${orphaned}  Stubbed: ${stubbed}`,
+		);
+		for (const entry of entries) {
+			const marker =
+				entry.status === "linked"
+					? chalk.green("✓")
+					: entry.status === "orphaned"
+						? chalk.red("✗")
+						: chalk.yellow("○");
+			const feature = entry.feature ? ` -> ${entry.feature}` : "";
+			const stubLabel =
+				entry.stubAssertions.length > 0 ? chalk.red(" [stub assertions]") : "";
+			console.log(`  ${marker} ${entry.path}${feature}${stubLabel}`);
+		}
+	});
+
+testCommand
+	.command("review")
+	.description("Review a test and record local clean state")
+	.argument("<path>", "Path to the test file")
+	.action(async (testPath: string) => {
+		try {
+			const record = await reviewTest(testPath);
+			console.log(chalk.green(`✓ Test reviewed: ${record.path}`));
+			if (record.feature) {
+				console.log(chalk.dim(`  Feature: ${record.feature}`));
+			}
+			console.log(chalk.dim(`  Review count: ${record.reviewCount}`));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(chalk.red(`✗ ${message}`));
+			process.exit(1);
+		}
+	});
+
+testCommand
+	.command("status")
+	.description("Show local test review state")
+	.option("--json", "Output review state as JSON")
+	.action(async (options: { json?: boolean }) => {
+		const manifest = await loadTestReviewManifest();
+		if (options.json) {
+			console.log(JSON.stringify(manifest, null, 2));
+			return;
+		}
+
+		console.log(chalk.bold("Test Review Status"));
+		console.log(chalk.dim("=================="));
+		if (manifest.tests.length === 0) {
+			console.log(chalk.yellow("No reviewed tests found."));
+			console.log(
+				chalk.dim("Run `udd test review <path>` after reviewing a test."),
+			);
+			return;
+		}
+
+		for (const test of manifest.tests) {
+			const marker =
+				test.status === "clean" ? chalk.green("✓") : chalk.red("✗");
+			const reviewed = test.lastReviewed
+				? test.lastReviewed.split("T")[0]
+				: "never";
+			const reason = test.dirtyReason ? ` (${test.dirtyReason})` : "";
+			console.log(`  ${marker} ${test.path} ${chalk.dim(reviewed)}${reason}`);
+		}
+	});
+
+testCommand
+	.command("gate")
+	.description("Run explicit local test-governance gate checks")
+	.option(
+		"--strict",
+		"Fail on gate findings instead of reporting advisory status",
+	)
+	.option("--json", "Output gate result as JSON")
+	.action(async (options: { strict?: boolean; json?: boolean }) => {
+		const result = await checkTestGate();
+		if (options.json) {
+			console.log(JSON.stringify(result, null, 2));
+			if (options.strict && !result.passed) process.exit(1);
+			return;
+		}
+
+		if (result.passed) {
+			console.log(chalk.green("✓ Test governance gate passed"));
+			return;
+		}
+
+		console.log(chalk.yellow("Test governance findings"));
+		for (const issue of result.reviewManifestIssues) {
+			console.log(chalk.red(`  Review manifest issue: ${issue}`));
+		}
+		for (const entry of result.stubbedTests) {
+			console.log(chalk.red(`  Stub assertions: ${entry.path}`));
+		}
+		for (const entry of result.orphanedTests) {
+			console.log(
+				chalk.red(`  Orphaned feature link: ${entry.path} -> ${entry.feature}`),
+			);
+		}
+		for (const entry of result.dirtyReviews) {
+			console.log(chalk.red(`  Dirty review: ${entry.path}`));
+		}
+
+		if (options.strict) {
+			process.exit(1);
+		} else {
+			console.log(
+				chalk.dim(
+					"Advisory only. Use `udd test gate --strict` to fail on findings.",
+				),
+			);
+		}
 	});

--- a/src/lib/test-governance.ts
+++ b/src/lib/test-governance.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { glob } from "glob";
+import yaml from "yaml";
+import {
+	type TestReviewManifest,
+	TestReviewManifestSchema,
+	type TestReviewRecord,
+} from "../types.js";
+
+export interface TestScanEntry {
+	path: string;
+	feature?: string;
+	stubAssertions: string[];
+	status: "linked" | "unlinked" | "orphaned";
+}
+
+export interface TestGateResult {
+	passed: boolean;
+	entries: TestScanEntry[];
+	dirtyReviews: TestReviewRecord[];
+	stubbedTests: TestScanEntry[];
+	orphanedTests: TestScanEntry[];
+	reviewManifestIssues: string[];
+}
+
+export const TEST_REVIEW_MANIFEST = ".udd/test-reviews.yml";
+
+function toPosix(filePath: string): string {
+	return filePath.replace(/\\/g, "/");
+}
+
+function normalizeFeatureReference(reference: string): string {
+	if (reference.startsWith("specs/features/")) {
+		return reference.endsWith(".feature")
+			? toPosix(reference)
+			: `${toPosix(reference)}.feature`;
+	}
+	const normalized = toPosix(reference);
+	return `specs/features/${normalized.endsWith(".feature") ? normalized : `${normalized}.feature`}`;
+}
+
+export function detectStubAssertions(content: string): string[] {
+	const patterns = [
+		/expect\(\s*true\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\s*\(\s*true\s*\)/g,
+		/expect\(\s*false\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\s*\(\s*false\s*\)/g,
+		/expect\(\s*(['"`])([^'"`]+)\1\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\s*\(\s*\1\2\1\s*\)/g,
+		/expect\(\s*(\d+)\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\s*\(\s*\1\s*\)/g,
+	];
+
+	const matches = new Set<string>();
+	for (const pattern of patterns) {
+		for (;;) {
+			const match = pattern.exec(content);
+			if (!match) break;
+			matches.add(match[0]);
+		}
+	}
+	return [...matches];
+}
+
+export function extractFeatureReference(content: string): string | undefined {
+	const loadFeature = content.match(
+		/loadFeature\(\s*["']([^"']+\.feature)["']/,
+	);
+	if (loadFeature?.[1]) {
+		return normalizeFeatureReference(loadFeature[1]);
+	}
+
+	const featureComment =
+		content.match(/@feature\s+([^\s]+?\.feature)\b/) ??
+		content.match(/@feature\s+([^\s]+)/);
+	if (featureComment?.[1]) {
+		return normalizeFeatureReference(featureComment[1]);
+	}
+
+	return undefined;
+}
+
+export async function scanTests(
+	rootDir = process.cwd(),
+): Promise<TestScanEntry[]> {
+	const files = await glob("tests/**/*.{test,e2e.test}.{ts,tsx,js,jsx}", {
+		cwd: rootDir,
+		nodir: true,
+	});
+	const entries: TestScanEntry[] = [];
+
+	for (const file of files.sort()) {
+		const content = await fs.readFile(path.join(rootDir, file), "utf-8");
+		const feature = extractFeatureReference(content);
+		const stubAssertions = detectStubAssertions(content);
+		let status: TestScanEntry["status"] = "unlinked";
+
+		if (feature) {
+			try {
+				await fs.access(path.join(rootDir, feature));
+				status = "linked";
+			} catch {
+				status = "orphaned";
+			}
+		}
+
+		entries.push({
+			path: toPosix(file),
+			feature,
+			stubAssertions,
+			status,
+		});
+	}
+
+	return entries;
+}
+
+export async function loadTestReviewManifest(
+	rootDir = process.cwd(),
+): Promise<TestReviewManifest> {
+	const result = await readTestReviewManifest(rootDir);
+	return result.manifest;
+}
+
+async function readTestReviewManifest(rootDir = process.cwd()): Promise<{
+	manifest: TestReviewManifest;
+	issues: string[];
+}> {
+	const manifestPath = path.join(rootDir, TEST_REVIEW_MANIFEST);
+	try {
+		const parsed = yaml.parse(await fs.readFile(manifestPath, "utf-8"));
+		const result = TestReviewManifestSchema.safeParse(parsed);
+		if (result.success) return { manifest: result.data, issues: [] };
+		return {
+			manifest: { tests: [] },
+			issues: [`${TEST_REVIEW_MANIFEST} does not match the review schema.`],
+		};
+	} catch (error) {
+		try {
+			await fs.access(manifestPath);
+		} catch {
+			return { manifest: { tests: [] }, issues: [] };
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			manifest: { tests: [] },
+			issues: [`${TEST_REVIEW_MANIFEST} could not be parsed: ${message}`],
+		};
+	}
+}
+
+export async function saveTestReviewManifest(
+	manifest: TestReviewManifest,
+	rootDir = process.cwd(),
+): Promise<void> {
+	const manifestPath = path.join(rootDir, TEST_REVIEW_MANIFEST);
+	await fs.mkdir(path.dirname(manifestPath), { recursive: true });
+	await fs.writeFile(manifestPath, yaml.stringify(manifest));
+}
+
+export async function reviewTest(
+	testPath: string,
+	rootDir = process.cwd(),
+): Promise<TestReviewRecord> {
+	const absolutePath = path.isAbsolute(testPath)
+		? testPath
+		: path.join(rootDir, testPath);
+	const normalizedPath = toPosix(path.relative(rootDir, absolutePath));
+	const content = await fs.readFile(absolutePath, "utf-8");
+	const stubAssertions = detectStubAssertions(content);
+
+	if (stubAssertions.length > 0) {
+		throw new Error(
+			`Stub assertions detected in ${normalizedPath}: ${stubAssertions.join(", ")}`,
+		);
+	}
+
+	const feature = extractFeatureReference(content);
+	const manifest = await loadTestReviewManifest(rootDir);
+	const previous = manifest.tests.find(
+		(entry) => entry.path === normalizedPath,
+	);
+	const record: TestReviewRecord = {
+		path: normalizedPath,
+		feature,
+		status: "clean",
+		lastReviewed: new Date().toISOString(),
+		reviewCount: (previous?.reviewCount ?? 0) + 1,
+		dirtyReason: null,
+	};
+
+	manifest.tests = [
+		...manifest.tests.filter((entry) => entry.path !== normalizedPath),
+		record,
+	].sort((left, right) => left.path.localeCompare(right.path));
+	await saveTestReviewManifest(manifest, rootDir);
+	return record;
+}
+
+export async function checkTestGate(
+	rootDir = process.cwd(),
+): Promise<TestGateResult> {
+	const entries = await scanTests(rootDir);
+	const manifestResult = await readTestReviewManifest(rootDir);
+	const manifest = manifestResult.manifest;
+	const dirtyReviews = manifest.tests.filter(
+		(entry) => entry.status === "dirty",
+	);
+	const stubbedTests = entries.filter(
+		(entry) => entry.stubAssertions.length > 0,
+	);
+	const orphanedTests = entries.filter((entry) => entry.status === "orphaned");
+
+	return {
+		passed:
+			manifestResult.issues.length === 0 &&
+			dirtyReviews.length === 0 &&
+			stubbedTests.length === 0 &&
+			orphanedTests.length === 0,
+		entries,
+		dirtyReviews,
+		stubbedTests,
+		orphanedTests,
+		reviewManifestIssues: manifestResult.issues,
+	};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,3 +95,22 @@ export type FeatureSpec = z.infer<typeof FeatureSpecSchema>;
 export type TechnicalRequirement = z.infer<typeof TechnicalRequirementSchema>;
 export type SpecChange = z.infer<typeof SpecChangeSchema>;
 export type ResearchMetadata = z.infer<typeof ResearchMetadataSchema>;
+
+export const TestReviewStatusSchema = z.enum(["clean", "dirty"]);
+
+export const TestReviewRecordSchema = z.object({
+	path: z.string(),
+	feature: z.string().optional(),
+	status: TestReviewStatusSchema,
+	lastReviewed: z.string().datetime().nullable(),
+	reviewCount: z.number().default(0),
+	dirtyReason: z.string().nullable(),
+});
+
+export const TestReviewManifestSchema = z.object({
+	tests: z.array(TestReviewRecordSchema).default([]),
+});
+
+export type TestReviewStatus = z.infer<typeof TestReviewStatusSchema>;
+export type TestReviewRecord = z.infer<typeof TestReviewRecordSchema>;
+export type TestReviewManifest = z.infer<typeof TestReviewManifestSchema>;

--- a/tests/e2e/udd/test-governance/local-gate-validation.e2e.test.ts
+++ b/tests/e2e/udd/test-governance/local-gate-validation.e2e.test.ts
@@ -1,0 +1,305 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { afterAll, expect } from "vitest";
+import { rootDir, runUdd } from "../../../utils.js";
+
+const feature = await loadFeature(
+	"specs/features/udd/test-governance/local-gate-validation.feature",
+);
+
+let tempDir: string | undefined;
+
+async function cleanupProject(): Promise<void> {
+	process.chdir(rootDir);
+	if (tempDir) {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+}
+
+async function enterProject(): Promise<void> {
+	await cleanupProject();
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "udd-test-governance-"));
+	process.chdir(tempDir);
+	await runUdd("init --yes");
+}
+
+async function writeFeature(filePath: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(
+		filePath,
+		`Feature: Login
+  Scenario: User logs in
+    Given a user exists
+    When the user logs in
+    Then the user is authenticated
+`,
+	);
+}
+
+async function writeTest(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content);
+}
+
+async function runUddFailure(
+	args: string,
+): Promise<{ stdout: string; stderr: string }> {
+	try {
+		await runUdd(args);
+		throw new Error(`Expected udd ${args} to fail`);
+	} catch (error) {
+		const failure = error as { stdout?: string; stderr?: string };
+		return {
+			stdout: failure.stdout ?? "",
+			stderr: failure.stderr ?? "",
+		};
+	}
+}
+
+afterAll(cleanupProject);
+
+describeFeature(feature, ({ Background, Scenario }) => {
+	Background(({ Given }) => {
+		Given("a UDD project is initialized", async () => {
+			await enterProject();
+		});
+	});
+
+	Scenario(
+		"Scan tests for governance findings",
+		({ Given, When, Then, And }) => {
+			let scan: {
+				summary: {
+					linked: number;
+					unlinked: number;
+					orphaned: number;
+					stubbed: number;
+				};
+				tests: Array<{ path: string; feature?: string; status: string }>;
+			};
+
+			Given(
+				"the project has linked, unlinked, orphaned, and stubbed tests",
+				async () => {
+					await writeFeature("specs/features/auth/login.feature");
+					await writeTest(
+						"tests/auth/login.e2e.test.ts",
+						`import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+const feature = await loadFeature("specs/features/auth/login.feature");
+describeFeature(feature, ({ Scenario }) => {
+  Scenario("User logs in", ({ Then }) => {
+    Then("the user is authenticated", () => {
+      expect(1 + 1).toBe(2);
+    });
+  });
+});
+`,
+					);
+					await writeTest(
+						"tests/auth/unlinked.test.ts",
+						`import { expect, test } from "vitest";
+test("unlinked", () => expect(1 + 1).toBe(2));
+`,
+					);
+					await writeTest(
+						"tests/auth/orphaned.test.ts",
+						`// @feature auth/missing
+import { expect, test } from "vitest";
+test("orphaned", () => expect(1 + 1).toBe(2));
+`,
+					);
+					await writeTest(
+						"tests/auth/stubbed.test.ts",
+						`import { expect, test } from "vitest";
+test("stubbed", () => expect(true).toBe(true));
+`,
+					);
+				},
+			);
+
+			When('I run "udd test scan --json"', async () => {
+				const result = await runUdd("test scan --json");
+				scan = JSON.parse(result.stdout);
+			});
+
+			Then(
+				"the scan reports linked, unlinked, orphaned, and stubbed counts",
+				() => {
+					expect(scan.summary.linked).toBe(1);
+					expect(scan.summary.unlinked).toBe(2);
+					expect(scan.summary.orphaned).toBe(1);
+					expect(scan.summary.stubbed).toBe(1);
+				},
+			);
+
+			And("the linked test includes its feature path", () => {
+				expect(scan.tests).toContainEqual(
+					expect.objectContaining({
+						path: "tests/auth/login.e2e.test.ts",
+						feature: "specs/features/auth/login.feature",
+						status: "linked",
+					}),
+				);
+			});
+		},
+	);
+
+	Scenario(
+		"Resolve feature comment references with feature extension",
+		({ Given, When, Then }) => {
+			let scan: {
+				tests: Array<{ path: string; feature?: string; status: string }>;
+			};
+
+			Given(
+				'the project has a test linked by an "@feature" comment ending in ".feature" plus punctuation',
+				async () => {
+					await writeFeature("specs/features/auth/login.feature");
+					await writeTest(
+						"tests/auth/comment-linked.e2e.test.ts",
+						`// @feature auth/login.feature.
+import { expect, test } from "vitest";
+test("login", () => expect(1 + 1).toBe(2));
+`,
+					);
+				},
+			);
+
+			When('I run "udd test scan --json"', async () => {
+				const result = await runUdd("test scan --json");
+				scan = JSON.parse(result.stdout);
+			});
+
+			Then("the feature comment test is reported as linked", () => {
+				expect(scan.tests).toContainEqual(
+					expect.objectContaining({
+						path: "tests/auth/comment-linked.e2e.test.ts",
+						feature: "specs/features/auth/login.feature",
+						status: "linked",
+					}),
+				);
+			});
+		},
+	);
+
+	Scenario("Record a local test review", ({ Given, When, Then, And }) => {
+		let reviewOutput = "";
+
+		Given("the project has a meaningful linked test", async () => {
+			await writeFeature("specs/features/auth/login.feature");
+			await writeTest(
+				"tests/auth/login.e2e.test.ts",
+				`import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+const feature = await loadFeature("specs/features/auth/login.feature");
+describeFeature(feature, ({ Scenario }) => {
+  Scenario("User logs in", ({ Then }) => {
+    Then("the user is authenticated", () => {
+      expect(1 + 1).toBe(2);
+    });
+  });
+});
+`,
+			);
+		});
+
+		When('I run "udd test review tests/auth/login.e2e.test.ts"', async () => {
+			const result = await runUdd("test review tests/auth/login.e2e.test.ts");
+			reviewOutput = result.stdout;
+		});
+
+		Then("the test review manifest records the test as clean", async () => {
+			const manifest = await fs.readFile(".udd/test-reviews.yml", "utf-8");
+			expect(manifest).toContain("path: tests/auth/login.e2e.test.ts");
+			expect(manifest).toContain("status: clean");
+			expect(reviewOutput).toContain("Test reviewed");
+		});
+
+		And('"udd test status --json" reports the review record', async () => {
+			const status = JSON.parse((await runUdd("test status --json")).stdout);
+			expect(status.tests).toContainEqual(
+				expect.objectContaining({
+					path: "tests/auth/login.e2e.test.ts",
+					status: "clean",
+				}),
+			);
+		});
+	});
+
+	Scenario("Run an explicit local gate", ({ Given, When, Then }) => {
+		let advisory = "";
+		let strict = "";
+
+		Given("the project has dirty local review state", async () => {
+			await fs.mkdir(".udd", { recursive: true });
+			await fs.writeFile(
+				".udd/test-reviews.yml",
+				`tests:
+  - path: tests/auth/login.e2e.test.ts
+    status: dirty
+    lastReviewed: null
+    reviewCount: 1
+    dirtyReason: Feature changed after review
+`,
+			);
+		});
+
+		When('I run "udd test gate"', async () => {
+			const result = await runUdd("test gate");
+			advisory = result.stdout;
+		});
+
+		Then("the gate reports findings without failing", () => {
+			expect(advisory).toContain("Test governance findings");
+			expect(advisory).toContain("Dirty review: tests/auth/login.e2e.test.ts");
+			expect(advisory).toContain("Advisory only");
+		});
+
+		When('I run "udd test gate --strict"', async () => {
+			const result = await runUddFailure("test gate --strict");
+			strict = `${result.stdout}\n${result.stderr}`;
+		});
+
+		Then("the strict gate fails with the dirty test listed", () => {
+			expect(strict).toContain("Dirty review: tests/auth/login.e2e.test.ts");
+		});
+	});
+
+	Scenario(
+		"Block strict gates on invalid local review state",
+		({ Given, When, Then }) => {
+			let strict = "";
+
+			Given("the project has an invalid local review manifest", async () => {
+				await fs.mkdir(".udd", { recursive: true });
+				await fs.writeFile(
+					".udd/test-reviews.yml",
+					`tests:
+  - path: tests/auth/login.e2e.test.ts
+    status: unknown
+    lastReviewed: null
+    reviewCount: 1
+    dirtyReason: null
+`,
+				);
+			});
+
+			When('I run "udd test gate --strict"', async () => {
+				const result = await runUddFailure("test gate --strict");
+				strict = `${result.stdout}\n${result.stderr}`;
+			});
+
+			Then(
+				"the strict gate fails with the review manifest issue listed",
+				() => {
+					expect(strict).toContain("Review manifest issue");
+					expect(strict).toContain(".udd/test-reviews.yml");
+				},
+			);
+		},
+	);
+});


### PR DESCRIPTION
## Objective

Closes #55 by landing a focused test-governance salvage slice from `origin/codex/source-of-truth-cleanup-base` onto current `master` after PR #63.

This PR intentionally keeps the behavior local and explicit: it adds test scanning, local review records, and an opt-in `udd test gate` command that is advisory unless `--strict` is requested.

## Scope

Included:
- `udd test scan` to inventory tests, feature links, orphaned links, and stub assertions.
- `udd test review` and `udd test status` backed by local `.udd/test-reviews.yml` state.
- `udd test gate` / `udd test gate --strict` for explicit local gate behavior.
- One canonical BDD scenario file plus E2E coverage for the local gate slice.
- Roadmap/use-case links marking the delivered part of test governance as partial while leaving broader follow-ups future-scoped.

Intentionally excluded:
- Broad CI workflow gates from the side branch.
- Pre-commit/hook installation changes.
- Generated `.udd/config.yml`, `.memsearch.yaml`, lockfile/tooling churn, and stale generated state.
- Metric-only cleanup, skipped tests, and unrelated phase/doctor/health implementation changes.

## Independent review

A separate Codex review found two blocking issues before PR creation:
- malformed `.udd/test-reviews.yml` was treated as empty state;
- `@feature auth/login.feature` normalized incorrectly.

Both were fixed and covered with new E2E scenarios. Re-review found no blocking findings and said PR creation is acceptable.

## Validation

Local validation run on this branch:

```bash
./bin/udd lint
./node_modules/.bin/tsc --noEmit
PATH="$HOME/.bun/bin:$PATH" bunx biome check .
PATH="$HOME/.bun/bin:$PATH" UDD_TEST_RUNTIME=bun ./bin/udd test tests/e2e/udd/test-governance/local-gate-validation.e2e.test.ts
PATH="$HOME/.bun/bin:$PATH" UDD_TEST_RUNTIME=bun ./bin/udd test
```

Results:
- `udd lint`: passed.
- `tsc --noEmit`: passed.
- `biome check .`: passed.
- Focused E2E: passed, 1 file / 24 tests.
- Full test suite: passed, 39 files / 346 tests.

Health/doctor check remains warning-only because of existing roadmap/journey drift:

```json
{"healthy":false,"status":"drift-detected","summary":{"critical":0,"warning":54,"info":0,"total":54}}
```

## Notes

This does not enable broad gate behavior by default. `udd test gate` reports findings without failing; `udd test gate --strict` is the explicit failure mode for local use and future CI/hook integration.