### PR TITLE
feat: salvage OpenCode shared integration

### DIFF
--- a/.opencode/command/udd/health.md
+++ b/.opencode/command/udd/health.md
@@ -1,0 +1,23 @@
+---
+description: Show UDD diagnostics for OpenCode sessions
+agent: quick-status
+---
+
+# /udd/health Command
+
+Run UDD diagnostics and summarize project health for the current OpenCode
+session.
+
+## Execute Diagnostics
+
+!`./bin/udd doctor`
+
+## Execute OpenCode Issue Payload
+
+!`./bin/udd opencode issues`
+
+## Summary
+
+Report critical issues first, then warnings. If the diagnostics show only
+warnings from known roadmap or journey drift, call that out as warning-level
+state and recommend the next focused command to run.

--- a/.opencode/command/udd/iterate.md
+++ b/.opencode/command/udd/iterate.md
@@ -12,6 +12,9 @@ Autonomous iteration loop for UDD projects. Use this to drive continuous progres
 ### Status (JSON)
 !`./bin/udd status --json`
 
+### OpenCode Adapter Recommendation
+!`./bin/udd opencode next --json`
+
 ### Git State
 !`git status --short`
 
@@ -27,6 +30,8 @@ From the JSON status above, identify:
 3. Any `missing` scenarios - these need test files
 4. Any `stale` scenarios - run `/udd/test` first
 5. Git state - commit completed work before continuing
+6. OpenCode recommendation - use it only when it agrees with UDD status and the
+   current user request.
 
 ### Step 2: Check Completion
 

--- a/.opencode/command/udd/status.md
+++ b/.opencode/command/udd/status.md
@@ -11,6 +11,10 @@ Run the UDD status command and provide a concise assessment.
 
 !`./bin/udd status`
 
+## Execute OpenCode Adapter Status
+
+!`./bin/udd opencode status`
+
 ## Analysis
 
 Based on the status output:
@@ -19,6 +23,8 @@ Based on the status output:
 2. **Health Check**: Any unsatisfied outcomes or failing scenarios?
 3. **Stale Tests**: Are test results current or stale?
 4. **Git State**: Is the working directory clean?
+5. **Adapter State**: Does `udd opencode status` show the same phase, health,
+   and issue counts from shared UDD state?
 
 ## Summary
 

--- a/bin/udd.ts
+++ b/bin/udd.ts
@@ -8,6 +8,7 @@ import { inboxCommand } from "../src/commands/inbox.js";
 import { initCommand } from "../src/commands/init.js";
 import { lintCommand } from "../src/commands/lint.js";
 import { newCommand } from "../src/commands/new.js";
+import { opencodeCommand } from "../src/commands/opencode.js";
 import { phaseCommand } from "../src/commands/phase.js";
 import { queryCommand } from "../src/commands/query.js";
 import { statusCommand } from "../src/commands/status.js";
@@ -33,5 +34,6 @@ program.addCommand(testCommand);
 program.addCommand(inboxCommand);
 program.addCommand(queryCommand);
 program.addCommand(hooksCommand);
+program.addCommand(opencodeCommand);
 
 program.parse(process.argv);

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,31 @@
+# OpenCode Adapter
+
+OpenCode is UDD's dogfooded agent adapter. The root `.opencode/` directory is
+intentional project state for this repository: it contains OpenCode command,
+agent, and plugin files used while developing UDD itself.
+
+## Runtime Surface
+
+- `.opencode/command/udd/*.md` - OpenCode slash-command prompts.
+- `.opencode/agent/*.md` - OpenCode agent profiles for UDD work.
+- `.opencode/plugin/udd-enforcement.ts` - OpenCode-specific local workflow
+  warnings.
+- `udd opencode status` - deep project status for OpenCode sessions.
+- `udd opencode next` - next-work recommendation backed by shared UDD status.
+- `udd opencode issues` - diagnostic issue list backed by shared UDD doctor
+  logic.
+
+## Shared Dependencies
+
+OpenCode adapter commands use `src/lib/agent-integration.ts` for payload shape,
+scenario totals, diagnostic issue mapping, and next-work recommendations. This
+keeps OpenCode-specific UX separate from shared UDD source-of-truth behavior.
+
+## Scope Boundaries
+
+- Root `.opencode/` files are committed because this repository dogfoods
+  OpenCode directly.
+- Generated OpenCode dependencies and package-manager state are not part of the
+  source contract.
+- Codex behavior is not defined here; Codex hook installation remains the
+  installable external-project tooling from PR #46.

--- a/integrations/shared/README.md
+++ b/integrations/shared/README.md
@@ -1,0 +1,25 @@
+# Shared Agent Integration
+
+Shared integration files describe UDD behavior that every agent adapter can
+reuse. Runtime-specific files can live under `.opencode/`, `.codex/`, or future
+adapter directories, but they should call the same UDD project-state and
+diagnostic surfaces instead of redefining source-of-truth rules.
+
+## Current Contract
+
+- Project state: `src/lib/status.ts`
+- Diagnostic issues: `src/lib/diagnostics.ts`
+- Agent payload shaping: `src/lib/agent-integration.ts`
+- Verification commands: `udd status`, `udd doctor`, `udd lint`, and focused
+  `udd test` runs
+
+This shared layer intentionally does not make Codex goal commands part of UDD's
+adapter architecture. Codex hook installation remains the opt-in external
+project tooling added by PR #46.
+
+## Adapter Rules
+
+Adapters may add runtime prompts, slash commands, plugins, or UI helpers. They
+must not duplicate UDD source-of-truth policy. If an adapter needs a new status
+field, recommendation field, or diagnostic category, add it to shared source
+first and then expose it through the adapter.

--- a/specs/features/opencode/tools/issues_list.feature
+++ b/specs/features/opencode/tools/issues_list.feature
@@ -1,0 +1,11 @@
+@phase:3
+Feature: OpenCode issue list
+
+  As an OpenCode agent checking a UDD repository
+  I want diagnostic issues in a stable JSON shape
+  So that I can report blockers and warnings consistently
+
+  Scenario: Issues command returns shared diagnostic issues
+    When the OpenCode adapter requests issues as JSON
+    Then the payload includes status, summary counts, and issue records
+    And each issue record includes a recommendation

--- a/specs/features/opencode/tools/next_recommendation.feature
+++ b/specs/features/opencode/tools/next_recommendation.feature
@@ -1,0 +1,11 @@
+@phase:3
+Feature: OpenCode next recommendation
+
+  As an OpenCode agent working through UDD backlog
+  I want a next-work recommendation from shared status
+  So that I can pick focused work without inventing a separate priority model
+
+  Scenario: Next command returns a structured recommendation
+    When the OpenCode adapter requests the next recommendation as JSON
+    Then the payload includes the recommended item, reason, suggested files, and blockers
+    And the recommendation is derived from current UDD status and diagnostics

--- a/specs/features/opencode/tools/status_deep.feature
+++ b/specs/features/opencode/tools/status_deep.feature
@@ -1,0 +1,11 @@
+@phase:3
+Feature: OpenCode deep status
+
+  As an OpenCode agent working in a UDD repository
+  I want a shared deep status payload
+  So that I can make project decisions without scraping human output
+
+  Scenario: Status command returns shared project status JSON
+    When the OpenCode adapter requests deep status as JSON
+    Then the payload includes project identity, phase, git state, health, and scenario totals
+    And the payload does not define Codex hook or goal-command behavior

--- a/specs/roadmap.yml
+++ b/specs/roadmap.yml
@@ -130,20 +130,16 @@ phases:
           - status_prompt
           - guide_user
           - codex_hooks
-        future_scenarios:
-          follow_up: "#54"
-          scenarios:
-            - status_deep
-            - next_recommendation
-            - issues_list
-          scenario_paths:
-            - opencode/tools/status_deep
-            - opencode/tools/next_recommendation
-            - opencode/tools/issues_list
+          - status_deep
+          - next_recommendation
+          - issues_list
         scenario_paths:
           - udd/agent/status_prompt
           - udd/agent/guide_user
           - udd/cli/codex_hooks
+          - opencode/tools/status_deep
+          - opencode/tools/next_recommendation
+          - opencode/tools/issues_list
       - id: capture_ideas
         capability: idea-management
         increment: v1-basic

--- a/specs/use-cases/agent_customization.yml
+++ b/specs/use-cases/agent_customization.yml
@@ -20,21 +20,17 @@ outcomes:
       - codex_hooks
     scenario_paths:
       - udd/cli/codex_hooks
-future_outcomes:
   - description: OpenCode adapter can check deep status
-    follow_up: "#54"
     scenarios:
       - status_deep
     scenario_paths:
       - opencode/tools/status_deep
   - description: OpenCode adapter can get next recommendation
-    follow_up: "#54"
     scenarios:
       - next_recommendation
     scenario_paths:
       - opencode/tools/next_recommendation
   - description: OpenCode adapter can list all issues
-    follow_up: "#54"
     scenarios:
       - issues_list
     scenario_paths:

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -1,0 +1,129 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import {
+	buildAgentIssueList,
+	buildAgentProjectSnapshot,
+	recommendNextAgentWork,
+} from "../lib/agent-integration.js";
+import { analyzeProjectDiagnostics } from "../lib/diagnostics.js";
+import { getProjectStatus } from "../lib/status.js";
+
+async function getAgentInputs() {
+	const [status, diagnostics] = await Promise.all([
+		getProjectStatus(),
+		analyzeProjectDiagnostics(),
+	]);
+
+	return { status, diagnostics };
+}
+
+export const opencodeCommand = new Command("opencode").description(
+	"OpenCode adapter commands backed by shared UDD project state",
+);
+
+opencodeCommand
+	.command("status")
+	.description("Show deep UDD project status for OpenCode sessions")
+	.option("--json", "Output JSON for agent consumption")
+	.action(async (options) => {
+		const { status, diagnostics } = await getAgentInputs();
+		const snapshot = buildAgentProjectSnapshot(status, diagnostics);
+
+		if (options.json) {
+			console.log(JSON.stringify(snapshot, null, 2));
+			return;
+		}
+
+		console.log(chalk.bold("OpenCode Agent Status"));
+		console.log(chalk.dim("====================="));
+		console.log("");
+		console.log(`Project: ${snapshot.project.name}`);
+		console.log(
+			`Current Phase: Phase ${snapshot.phase.current} - ${snapshot.phase.name}`,
+		);
+		console.log(
+			`Health: ${
+				snapshot.health.healthy
+					? chalk.green("healthy")
+					: chalk.yellow(snapshot.health.status)
+			}`,
+		);
+		console.log(
+			`Scenarios: ${snapshot.scenarios.total} total, ${snapshot.scenarios.passing} passing, ${snapshot.scenarios.failing} failing, ${snapshot.scenarios.missing} missing, ${snapshot.scenarios.stale} stale`,
+		);
+		console.log(
+			`Issues: ${snapshot.health.summary.total} total (${snapshot.health.summary.critical} critical, ${snapshot.health.summary.warning} warning, ${snapshot.health.summary.info} info)`,
+		);
+		console.log(
+			`Git: ${snapshot.git.branch} ${snapshot.git.clean ? "clean" : "dirty"}`,
+		);
+	});
+
+opencodeCommand
+	.command("next")
+	.description("Recommend the next UDD work item for an OpenCode session")
+	.option("--json", "Output JSON for agent consumption")
+	.action(async (options) => {
+		const { status, diagnostics } = await getAgentInputs();
+		const recommendation = recommendNextAgentWork(status, diagnostics);
+
+		if (options.json) {
+			console.log(JSON.stringify(recommendation, null, 2));
+			return;
+		}
+
+		console.log(chalk.bold("OpenCode Next Work"));
+		console.log(chalk.dim("=================="));
+		console.log("");
+		console.log(`Recommended: ${recommendation.recommended}`);
+		console.log(`Reason: ${recommendation.reason}`);
+		if (recommendation.suggested_files.length > 0) {
+			console.log("");
+			console.log(chalk.bold("Suggested Files:"));
+			for (const file of recommendation.suggested_files) {
+				console.log(`- ${file.path}: ${file.action}`);
+			}
+		}
+	});
+
+opencodeCommand
+	.command("issues")
+	.description("List UDD diagnostic issues for an OpenCode session")
+	.option("--json", "Output JSON for agent consumption")
+	.action(async (options) => {
+		const diagnostics = await analyzeProjectDiagnostics();
+		const issues = buildAgentIssueList(diagnostics);
+		const output = {
+			status: diagnostics.status,
+			healthy: diagnostics.healthy,
+			summary: diagnostics.summary,
+			issues,
+			generated_at: diagnostics.lastCheck,
+		};
+
+		if (options.json) {
+			console.log(JSON.stringify(output, null, 2));
+			return;
+		}
+
+		console.log(chalk.bold("OpenCode UDD Issues"));
+		console.log(chalk.dim("==================="));
+		console.log("");
+		console.log(
+			`Issues: ${output.summary.total} total (${output.summary.critical} critical, ${output.summary.warning} warning, ${output.summary.info} info)`,
+		);
+
+		for (const issue of issues) {
+			const color =
+				issue.severity === "critical"
+					? chalk.red
+					: issue.severity === "warning"
+						? chalk.yellow
+						: chalk.blue;
+			console.log("");
+			console.log(color(`${issue.severity.toUpperCase()} ${issue.type}`));
+			console.log(`File: ${issue.file}`);
+			console.log(issue.message);
+			console.log(chalk.dim(`Next: ${issue.recommendation}`));
+		}
+	});

--- a/src/lib/agent-integration.ts
+++ b/src/lib/agent-integration.ts
@@ -1,0 +1,290 @@
+import path from "node:path";
+import type { DiagnosticIssue, DiagnosticReport } from "./diagnostics.js";
+import type { FeatureStatus, ProjectStatus, ScenarioStatus } from "./status.js";
+
+export interface ScenarioTotals {
+	total: number;
+	passing: number;
+	failing: number;
+	missing: number;
+	stale: number;
+	deferred: number;
+}
+
+export interface AgentProjectSnapshot {
+	project: {
+		name: string;
+		root: string;
+	};
+	phase: {
+		current: number;
+		name: string;
+		all: Record<string, string>;
+	};
+	git: ProjectStatus["git"];
+	journeys: Array<{
+		name: string;
+		display_name: string;
+		actor: string;
+		goal: string;
+		status: "complete" | "incomplete" | "stale";
+		scenario_count: number;
+		scenarios_missing: number;
+		scenarios_passing: number;
+		scenarios_failing: number;
+		is_stale: boolean;
+	}>;
+	scenarios: ScenarioTotals;
+	health: {
+		status: DiagnosticReport["status"];
+		healthy: boolean;
+		summary: DiagnosticReport["summary"];
+	};
+	issues: AgentIssue[];
+	generated_at: string;
+}
+
+export interface AgentIssue {
+	id: string;
+	severity: DiagnosticIssue["severity"];
+	type: DiagnosticIssue["type"];
+	file: string;
+	message: string;
+	recommendation: string;
+	auto_fixable: boolean;
+}
+
+export interface AgentWorkRecommendation {
+	recommended: string;
+	reason: string;
+	suggested_files: Array<{ path: string; action: string }>;
+	blocking: AgentIssue[];
+	generated_at: string;
+}
+
+const AUTO_FIXABLE_TYPES = new Set<DiagnosticIssue["type"]>([
+	"manifest_missing",
+	"journey_stale",
+	"missing_scenario",
+]);
+
+function isCurrentPhaseScenario(
+	scenario: ScenarioStatus,
+	currentPhase: number,
+): boolean {
+	return (
+		!scenario.isDeferred && (!scenario.phase || scenario.phase <= currentPhase)
+	);
+}
+
+function getFeaturePaths(
+	feature: FeatureStatus,
+	featureId: string,
+	slug: string,
+) {
+	const featurePath = feature.path || featureId;
+	return {
+		scenarioPath: `specs/features/${featurePath}/${slug}.feature`,
+		testPath: `tests/e2e/${featurePath}/${slug}.e2e.test.ts`,
+	};
+}
+
+export function getScenarioTotals(status: ProjectStatus): ScenarioTotals {
+	const totals: ScenarioTotals = {
+		total: 0,
+		passing: 0,
+		failing: 0,
+		missing: 0,
+		stale: 0,
+		deferred: 0,
+	};
+
+	for (const feature of Object.values(status.features)) {
+		for (const scenario of Object.values(feature.scenarios)) {
+			totals.total++;
+			totals[scenario.e2e]++;
+		}
+	}
+
+	return totals;
+}
+
+export function buildAgentIssueList(report: DiagnosticReport): AgentIssue[] {
+	return report.issues.map((issue) => ({
+		id: issue.id,
+		severity: issue.severity,
+		type: issue.type,
+		file: issue.file,
+		message: issue.message,
+		recommendation: issue.recommendation,
+		auto_fixable: AUTO_FIXABLE_TYPES.has(issue.type),
+	}));
+}
+
+export function buildAgentProjectSnapshot(
+	status: ProjectStatus,
+	report: DiagnosticReport,
+	root = process.cwd(),
+	now = new Date(),
+): AgentProjectSnapshot {
+	return {
+		project: {
+			name: path.basename(root) || "unknown",
+			root,
+		},
+		phase: {
+			current: status.current_phase,
+			name: status.phases[String(status.current_phase)] || "Unknown",
+			all: status.phases,
+		},
+		git: status.git,
+		journeys: Object.entries(status.journeys).map(([name, journey]) => ({
+			name,
+			display_name: journey.name,
+			actor: journey.actor,
+			goal: journey.goal,
+			status:
+				journey.scenariosMissing > 0 || journey.scenariosFailing > 0
+					? "incomplete"
+					: journey.isStale
+						? "stale"
+						: "complete",
+			scenario_count: journey.scenarioCount,
+			scenarios_missing: journey.scenariosMissing,
+			scenarios_passing: journey.scenariosPassing,
+			scenarios_failing: journey.scenariosFailing,
+			is_stale: journey.isStale,
+		})),
+		scenarios: getScenarioTotals(status),
+		health: {
+			status: report.status,
+			healthy: report.healthy,
+			summary: report.summary,
+		},
+		issues: buildAgentIssueList(report),
+		generated_at: now.toISOString(),
+	};
+}
+
+export function recommendNextAgentWork(
+	status: ProjectStatus,
+	report: DiagnosticReport,
+	now = new Date(),
+): AgentWorkRecommendation {
+	const issues = buildAgentIssueList(report);
+	const blocking = issues.filter((issue) => issue.severity === "critical");
+
+	if (blocking.length > 0) {
+		const firstBlocker = blocking[0];
+		return {
+			recommended: firstBlocker.file,
+			reason: firstBlocker.message,
+			suggested_files: [
+				{
+					path: firstBlocker.file,
+					action: firstBlocker.recommendation,
+				},
+			],
+			blocking,
+			generated_at: now.toISOString(),
+		};
+	}
+
+	for (const [featureId, feature] of Object.entries(status.features)) {
+		for (const [slug, scenario] of Object.entries(feature.scenarios)) {
+			if (
+				scenario.e2e === "failing" &&
+				isCurrentPhaseScenario(scenario, status.current_phase)
+			) {
+				const paths = getFeaturePaths(feature, featureId, slug);
+				return {
+					recommended: `${featureId}/${slug}`,
+					reason: "Current-phase scenario test is failing.",
+					suggested_files: [
+						{
+							path: paths.testPath,
+							action: "Fix the failing E2E test or implementation.",
+						},
+					],
+					blocking,
+					generated_at: now.toISOString(),
+				};
+			}
+		}
+	}
+
+	for (const [featureId, feature] of Object.entries(status.features)) {
+		for (const [slug, scenario] of Object.entries(feature.scenarios)) {
+			if (
+				scenario.e2e === "missing" &&
+				isCurrentPhaseScenario(scenario, status.current_phase)
+			) {
+				const paths = getFeaturePaths(feature, featureId, slug);
+				return {
+					recommended: `${featureId}/${slug}`,
+					reason: "Current-phase scenario is missing executable E2E coverage.",
+					suggested_files: [
+						{
+							path: paths.scenarioPath,
+							action: "Review the behavior contract.",
+						},
+						{
+							path: paths.testPath,
+							action: "Create executable E2E coverage.",
+						},
+					],
+					blocking,
+					generated_at: now.toISOString(),
+				};
+			}
+		}
+	}
+
+	for (const [featureId, feature] of Object.entries(status.features)) {
+		for (const [slug, scenario] of Object.entries(feature.scenarios)) {
+			if (
+				scenario.e2e === "stale" &&
+				isCurrentPhaseScenario(scenario, status.current_phase)
+			) {
+				const paths = getFeaturePaths(feature, featureId, slug);
+				return {
+					recommended: `${featureId}/${slug}`,
+					reason: "Current-phase scenario result is stale.",
+					suggested_files: [
+						{
+							path: paths.testPath,
+							action: "Run the test to refresh UDD status.",
+						},
+					],
+					blocking,
+					generated_at: now.toISOString(),
+				};
+			}
+		}
+	}
+
+	if (report.summary.total > 0) {
+		const firstIssue = issues[0];
+		return {
+			recommended: firstIssue.file,
+			reason: firstIssue.message,
+			suggested_files: [
+				{
+					path: firstIssue.file,
+					action: firstIssue.recommendation,
+				},
+			],
+			blocking,
+			generated_at: now.toISOString(),
+		};
+	}
+
+	return {
+		recommended: "none",
+		reason:
+			"No current-phase failing, missing, stale, or diagnostic work found.",
+		suggested_files: [],
+		blocking,
+		generated_at: now.toISOString(),
+	};
+}

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -31,6 +31,7 @@ export interface RequirementStatus {
 }
 
 export interface FeatureStatus {
+	path: string;
 	scenarios: Record<string, ScenarioStatus>;
 	requirements: Record<string, RequirementStatus>;
 }
@@ -256,9 +257,14 @@ export async function getProjectStatus(): Promise<ProjectStatus> {
 		}
 		const data = yaml.parse(content) as { id: string };
 		const featureId = data.id;
+		const featurePath = path
+			.dirname(file)
+			.replace(/\\/g, "/")
+			.replace(/^specs\/features\//, "");
 
 		status.active_features.push(featureId);
 		status.features[featureId] = {
+			path: featurePath,
 			scenarios: {},
 			requirements: {},
 		};

--- a/tests/e2e/opencode/tools/issues_list.e2e.test.ts
+++ b/tests/e2e/opencode/tools/issues_list.e2e.test.ts
@@ -1,0 +1,42 @@
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import { runUdd } from "../../../utils.js";
+
+const feature = await loadFeature(
+	"specs/features/opencode/tools/issues_list.feature",
+);
+
+describeFeature(feature, ({ Scenario }) => {
+	Scenario(
+		"Issues command returns shared diagnostic issues",
+		({ When, Then, And }) => {
+			let payload: {
+				status?: string;
+				summary?: { total?: number };
+				issues?: Array<{ recommendation?: string }>;
+			};
+
+			When("the OpenCode adapter requests issues as JSON", async () => {
+				const result = await runUdd("opencode issues --json");
+				payload = JSON.parse(result.stdout);
+			});
+
+			Then(
+				"the payload includes status, summary counts, and issue records",
+				() => {
+					expect(payload.status).toEqual(expect.any(String));
+					expect(payload.summary).toEqual(
+						expect.objectContaining({ total: expect.any(Number) }),
+					);
+					expect(payload.issues).toEqual(expect.any(Array));
+				},
+			);
+
+			And("each issue record includes a recommendation", () => {
+				for (const issue of payload.issues ?? []) {
+					expect(issue.recommendation).toEqual(expect.any(String));
+				}
+			});
+		},
+	);
+});

--- a/tests/e2e/opencode/tools/next_recommendation.e2e.test.ts
+++ b/tests/e2e/opencode/tools/next_recommendation.e2e.test.ts
@@ -1,0 +1,47 @@
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import { runUdd } from "../../../utils.js";
+
+const feature = await loadFeature(
+	"specs/features/opencode/tools/next_recommendation.feature",
+);
+
+describeFeature(feature, ({ Scenario }) => {
+	Scenario(
+		"Next command returns a structured recommendation",
+		({ When, Then, And }) => {
+			let payload: Record<string, unknown>;
+
+			When(
+				"the OpenCode adapter requests the next recommendation as JSON",
+				async () => {
+					const result = await runUdd("opencode next --json");
+					payload = JSON.parse(result.stdout);
+				},
+			);
+
+			Then(
+				"the payload includes the recommended item, reason, suggested files, and blockers",
+				() => {
+					expect(payload).toEqual(
+						expect.objectContaining({
+							recommended: expect.any(String),
+							reason: expect.any(String),
+							suggested_files: expect.any(Array),
+							blocking: expect.any(Array),
+							generated_at: expect.any(String),
+						}),
+					);
+				},
+			);
+
+			And(
+				"the recommendation is derived from current UDD status and diagnostics",
+				() => {
+					expect(payload.reason).not.toHaveLength(0);
+					expect(payload.recommended).not.toBeUndefined();
+				},
+			);
+		},
+	);
+});

--- a/tests/e2e/opencode/tools/status_deep.e2e.test.ts
+++ b/tests/e2e/opencode/tools/status_deep.e2e.test.ts
@@ -1,0 +1,62 @@
+import { describeFeature, loadFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import { runUdd } from "../../../utils.js";
+
+const feature = await loadFeature(
+	"specs/features/opencode/tools/status_deep.feature",
+);
+
+describeFeature(feature, ({ Scenario }) => {
+	Scenario(
+		"Status command returns shared project status JSON",
+		({ When, Then, And }) => {
+			let payload: Record<string, unknown>;
+
+			When("the OpenCode adapter requests deep status as JSON", async () => {
+				const result = await runUdd("opencode status --json");
+				payload = JSON.parse(result.stdout);
+			});
+
+			Then(
+				"the payload includes project identity, phase, git state, health, and scenario totals",
+				() => {
+					expect(payload.project).toMatchObject({ name: "udd" });
+					expect(payload.phase).toMatchObject({
+						current: 3,
+						name: "Agent Integration",
+					});
+					expect(payload.git).toEqual(
+						expect.objectContaining({
+							branch: expect.any(String),
+							clean: expect.any(Boolean),
+						}),
+					);
+					expect(payload.health).toEqual(
+						expect.objectContaining({
+							status: expect.any(String),
+							summary: expect.any(Object),
+						}),
+					);
+					expect(payload.scenarios).toEqual(
+						expect.objectContaining({
+							total: expect.any(Number),
+							passing: expect.any(Number),
+							failing: expect.any(Number),
+							missing: expect.any(Number),
+							stale: expect.any(Number),
+						}),
+					);
+				},
+			);
+
+			And(
+				"the payload does not define Codex hook or goal-command behavior",
+				() => {
+					const serialized = JSON.stringify(payload);
+					expect(serialized).not.toContain("install-codex");
+					expect(serialized).not.toContain("/goal");
+				},
+			);
+		},
+	);
+});


### PR DESCRIPTION
## Objective

Closes #54 by landing a focused OpenCode/shared agent integration salvage slice from `origin/codex/source-of-truth-cleanup-base` onto current `master` after PR #64.

This PR intentionally avoids the broad PR #45 stack. It keeps Codex behavior aligned with merged PR #46 by leaving Codex hook behavior as installable external-project tooling and not reintroducing Codex goal-command coupling.

## Scope

Included:
- Shared agent payload helpers in `src/lib/agent-integration.ts` for scenario totals, diagnostic issue mapping, project snapshots, and next-work recommendations.
- `udd opencode status`, `udd opencode next`, and `udd opencode issues` adapter commands backed by shared UDD status/doctor state.
- Current #54 OpenCode tool scenarios and focused E2E coverage for `status_deep`, `next_recommendation`, and `issues_list`.
- `integrations/shared/README.md` and `integrations/opencode/README.md` documenting adapter boundaries and root `.opencode/` as intentional UDD dogfooding state.
- OpenCode command prompt updates that call the new adapter surfaces.
- Gemini follow-up fixes for journey failing status, issue mapping reuse, and directory-based recommendation paths.

Intentionally excluded:
- PR #45 broad orchestration command imports.
- Shared `/goal` or Codex goal-command contract files.
- Codex hook changes from the side branch; PR #46 remains the source of truth.
- Generated `.opencode/node_modules`, `.opencode/bun.lock`, `.udd/config.yml`, `.memsearch.yaml`, and package/tooling cleanup.

## Audit/Roadmap Verification

Before implementation, I verified:
- PR #64 is merged into `master` and local `master` was fast-forwarded to `fb71102`.
- PR #45 is closed and unmerged, so this is a selective salvage task.
- PR #46 is merged and supersedes the Codex hook-installer portion of PR #45.
- `docs/project/reviews/2026-05-19-pr45-stack-audit/report.md` lists OpenCode/shared integration as follow-up slice #6.
- `specs/roadmap.yml` has `opencode-integration` as the active phase and tracks #54 under agent customization follow-up.

## Independent Review

A separate Codex review inspected the uncommitted diff before PR creation. Result: no blocking findings. The review specifically noted that the slice stays focused, avoids the old PR #45 `GoalCommandContract`/`/goal` coupling, and documents root `.opencode/` as dogfooding state.

## Gemini Review

Gemini commented after PR creation. I addressed the actionable feedback in commit `f96950d` and replied on the review threads:
- confirmed `issues_list` already has a matching `scenario_paths` entry;
- marked journeys with failing scenarios as `incomplete` in shared snapshots;
- reused the mapped issue list in `recommendNextAgentWork`;
- added `FeatureStatus.path` so recommendations use the discovered feature directory path instead of assuming feature id equals path.

## Validation

Local validation run on this branch:

```bash
./bin/udd lint
./node_modules/.bin/tsc --noEmit
PATH="$HOME/.bun/bin:$PATH" bunx biome check .
PATH="$HOME/.bun/bin:$PATH" UDD_TEST_RUNTIME=bun ./bin/udd test tests/e2e/opencode/tools/status_deep.e2e.test.ts tests/e2e/opencode/tools/next_recommendation.e2e.test.ts tests/e2e/opencode/tools/issues_list.e2e.test.ts
PATH="$HOME/.bun/bin:$PATH" UDD_TEST_RUNTIME=bun ./bin/udd test
git diff --check
```

Results after Gemini follow-up:
- `udd lint`: passed.
- `tsc --noEmit`: passed.
- `biome check .`: passed, 81 files.
- Focused OpenCode E2E: passed, 3 files / 9 tests.
- Full Bun-backed suite: passed, 42 files / 355 tests.
- `git diff --check`: passed.
- GitGuardian Security Checks: passed on `f96950d`.

The commit hook also ran related tests, `udd lint`, `tsc --noEmit`, and Biome on staged files before creating amended commit `f96950d`.

## Notes

`udd status` still reports existing warning-level roadmap/journey drift and stale scenario state. This PR does not attempt broad status cleanup; it adds shared/OpenCode surfaces that report that state consistently.