### PR TITLE
Define user-gap upgrade goal pipeline

### DIFF
--- a/docs/project/reviews/2026-06-02/user-gap-upgrade-review.md
+++ b/docs/project/reviews/2026-06-02/user-gap-upgrade-review.md
@@ -1,0 +1,287 @@
+# User-Gap Upgrade Review
+
+Date: 2026-06-02
+
+Remote head reviewed: `34773dbac1b63d489ce04abd322e5083c2b52325`
+
+## Purpose
+
+Review current remote `master` from user perspectives and identify upgrade-sized
+gaps that should become the next goal pipeline. The review focuses on friction
+that a user would notice, not only internal architecture gaps.
+
+## Evidence Collection
+
+The review evidence was collected from a fresh shallow clone of remote
+`master`, followed by `npm ci`.
+
+Commands run:
+
+```bash
+git clone --depth=1 --branch master https://github.com/rothnic/udd.git /tmp/udd-user-gap-review-remote
+cd /tmp/udd-user-gap-review-remote
+npm ci
+git rev-parse HEAD
+./bin/udd status --json > /tmp/udd-user-gap-evidence/status.json
+./bin/udd lint > /tmp/udd-user-gap-evidence/lint.txt
+./bin/udd trace --json > /tmp/udd-user-gap-evidence/trace.json
+./bin/udd impact specs/use-cases/run_tests.yml --json > /tmp/udd-user-gap-evidence/impact-run-tests.json
+./bin/udd doctor --json > /tmp/udd-user-gap-evidence/doctor.json
+./bin/udd repair --dry-run --json > /tmp/udd-user-gap-evidence/repair-dry-run.json
+./bin/udd opencode evidence --json --goal goals/000-strategic-execution-master-goal.md > /tmp/udd-user-gap-evidence/opencode-evidence.json
+```
+
+Every command above exited successfully. The raw command outputs were written
+to `/tmp/udd-user-gap-evidence/` during this review run; the durable summary
+below records the review-critical values so a future reviewer does not need
+chat history to understand the baseline.
+
+Observed evidence at `34773dbac1b63d489ce04abd322e5083c2b52325`:
+
+- `udd lint`: passed with `All specs are valid`.
+- `udd status --json`: 19 use cases, 14 active features, and 38 stale
+  scenarios.
+- `udd trace --json`: 159 nodes, 176 edges, and 20 diagnostics.
+- `udd impact specs/use-cases/run_tests.yml --json`: resolved one use case,
+  two scenarios, two linked E2E tests, and 11 edges.
+- `udd doctor --json`: `drift-detected`, `healthy: false`, 1 critical issue,
+  34 warnings, total 35 issues.
+- `udd repair --dry-run --json`: proposed 1 safe manifest refresh and refused
+  34 missing-scenario repairs as manual behavior-spec decisions.
+- `udd opencode evidence --json --goal goals/000-strategic-execution-master-goal.md`:
+  goal status `blocked`, next recommendation `specs/.udd/manifest.yml`, 1
+  critical issue, 34 warnings, `npm test -- --run` marked `not_run`.
+
+Review-critical JSON excerpts:
+
+```json
+{
+  "head": "34773dbac1b63d489ce04abd322e5083c2b52325",
+  "status": {
+    "current_phase": 3,
+    "active_features": 14,
+    "use_case_count": 19,
+    "scenario_totals": {
+      "stale": 38
+    }
+  },
+  "trace": {
+    "nodes": 159,
+    "edges": 176,
+    "diagnostics": 20
+  },
+  "impact_run_tests": {
+    "use_cases": ["use_case:run_tests"],
+    "scenarios": ["scenario:udd/cli/run_tests", "scenario:udd/cli/check_status"],
+    "tests": [
+      "test:tests/e2e/udd/cli/run_tests.e2e.test.ts",
+      "test:tests/e2e/udd/cli/check_status.e2e.test.ts"
+    ],
+    "edge_count": 11
+  },
+  "doctor": {
+    "status": "drift-detected",
+    "healthy": false,
+    "summary": {
+      "critical": 1,
+      "warning": 34,
+      "info": 0,
+      "total": 35
+    },
+    "missing_manifest": "specs/.udd/manifest.yml"
+  },
+  "repair_dry_run": {
+    "mode": "dry-run",
+    "proposed": 1,
+    "refused": 34,
+    "proposed_kinds": ["refresh_manifest"]
+  },
+  "agent_evidence": {
+    "goal_status": "blocked",
+    "next_recommended": "specs/.udd/manifest.yml",
+    "issues": {
+      "critical": 1,
+      "warning": 34,
+      "info": 0,
+      "total": 35
+    },
+    "verification": [
+      {"command": "./bin/udd status", "status": "passed"},
+      {"command": "./bin/udd lint", "status": "passed"},
+      {"command": "npm test -- --run", "status": "not_run"}
+    ]
+  }
+}
+```
+
+## Main Finding
+
+The current strategic-program report says goals 007-012 have source-controlled
+proof, but the default user-facing health surfaces still tell a fresh-checkout
+user that the project is blocked by a missing manifest and broad drift.
+
+That is the most important upgrade friction: UDD has proof artifacts, but the
+first status and evidence surfaces do not make the proved state feel trustworthy
+or ready to build on.
+
+## User Perspectives
+
+### Product Author
+
+Prompt: "I have a feature idea; help me create the right use case, scenario,
+and test obligation."
+
+What works:
+
+- Goal 007 and `docs/authoring-workbench.md` define the intended authoring
+  path.
+- The strategic command scenario confirms authoring should scaffold behavior
+  contracts without fake passing tests.
+
+Gaps:
+
+- The default status output still presents all outcomes as unsatisfied unless
+  prior test result state exists.
+- Authoring success is not connected to a visible "next proof obligation" queue
+  that ranks what a user should do after scaffolding.
+
+Classification:
+
+- `proof/reporting mismatch`: authoring proof exists, but status does not help
+  a new user trust it.
+- `missing feature coverage`: new/change/defer authoring paths need stronger
+  current-project examples tied to next verification commands.
+
+### Maintainer Or Reviewer
+
+Prompt: "Tell me whether this project is healthy and what changed."
+
+What works:
+
+- `udd trace --json` and `udd impact` provide deterministic relationships.
+- `udd lint` passes, so the source-controlled spec shape is valid.
+
+Gaps:
+
+- `udd doctor --json` reports `drift-detected` and `healthy: false` on a fresh
+  clone.
+- The missing `specs/.udd/manifest.yml` is critical even though generated local
+  state is not supposed to be source-of-truth evidence.
+- The status surface does not clearly separate current proof blockers from
+  optional journey/discovery drift.
+
+Classification:
+
+- `blocking upgrade friction`: a clean checkout looks unhealthy before the user
+  can evaluate the product.
+- `proof/reporting mismatch`: lint and strategic proof pass, but health
+  surfaces classify the project as blocked.
+
+### Test Governance Owner
+
+Prompt: "Show me which tests are proof, stale, missing, reviewed, or
+CI-blocking."
+
+What works:
+
+- Goal 009 and `local-gate-validation` establish the intended governance model.
+- `opencode evidence` refuses to infer full-suite success from generated local
+  state.
+
+Gaps:
+
+- Test-governance journeys still reference missing scenario files across
+  lifecycle, gates, health, and regression prevention.
+- Status reports stale scenarios broadly but does not give a user a crisp
+  governance upgrade path.
+- Strict/non-strict gate adoption needs stronger proof across the five
+  governance use cases.
+
+Classification:
+
+- `missing feature coverage`: current governance use cases have future or
+  journey-driven gaps.
+- `blocking upgrade friction`: teams cannot adopt UDD as a gate while the
+  default health model is noisy.
+
+### Recovery User
+
+Prompt: "This repo is drifted; diagnose it and safely repair what can be
+repaired."
+
+What works:
+
+- `udd doctor --json` identifies drift and separates issue severity.
+- `udd repair --dry-run --json` proposes only a safe manifest refresh and
+  refuses to rewrite behavior specs automatically.
+
+Gaps:
+
+- The only safe automatic action is generated-manifest refresh; the remaining
+  34 issues become manual without a guided recovery backlog.
+- The recovery journey has 14 missing scenario references, so the recovery
+  product promise is broader than canonical implemented behavior.
+
+Classification:
+
+- `missing feature coverage`: recovery workflow steps need canonical scenarios
+  and E2E proof.
+- `backlog/discovery drift`: recovery journey detail is still ahead of the
+  source-of-truth feature files.
+
+### Agent Operator
+
+Prompt: "Pick the next useful task, explain why, and produce reviewable
+evidence."
+
+What works:
+
+- `udd opencode evidence --json` returns adapter-neutral status, issues,
+  next recommendation, verification, changed files, and review notes.
+- Evidence marks full test verification as `not_run` unless explicit command
+  output exists.
+
+Gaps:
+
+- The next recommendation is the missing manifest, which is a generated-state
+  issue rather than a meaningful product upgrade.
+- The evidence package reports the strategic master goal as `blocked` even
+  though the strategic-program review says no final-program blocker remains.
+- Agents do not yet receive a durable goal pipeline that converts this mismatch
+  into upgrade work.
+
+Classification:
+
+- `proof/reporting mismatch`: strategic review and agent evidence disagree.
+- `blocking upgrade friction`: next-work selection can send agents to generated
+  state maintenance before user-visible product improvements.
+
+## Recommended Upgrade Pipeline
+
+Create a new goal program that treats goals 007-012 as historical/current
+strategic-program context and focuses goals 013-018 on user-visible upgrade
+friction:
+
+1. `goals/013-user-gap-upgrade-master-goal.md`
+2. `goals/014-status-trust-and-health-baseline.md`
+3. `goals/015-test-governance-upgrade.md`
+4. `goals/016-recovery-workflow-upgrade.md`
+5. `goals/017-change-impact-and-regression-upgrade.md`
+6. `goals/018-agent-operator-upgrade.md`
+
+Each goal should be a two-week upgrade increment with a visible user-facing
+promise, measurable outcomes, spec-first tasks, explicit verification commands,
+and independent user-perspective review gates.
+
+## Reviewer Blocking Criteria For The New Pipeline
+
+- Blocks if default status or doctor output still makes a clean, healthy
+  checkout look blocked by generated local state.
+- Blocks if optional journey drift is reported as equivalent to canonical
+  source-of-truth failure.
+- Blocks if governance goals do not add canonical scenarios and E2E proof for
+  missing test-governance behavior.
+- Blocks if recovery implementation rewrites user-authored behavior specs
+  without explicit review.
+- Blocks if agent next-work recommendations prioritize generated state over
+  meaningful user-visible product improvements without explaining why.

--- a/goals/013-user-gap-upgrade-master-goal.md
+++ b/goals/013-user-gap-upgrade-master-goal.md
@@ -1,0 +1,118 @@
+# Goal 013: User-Gap Upgrade Master Goal
+
+## Agent Entry
+
+Use this master goal to execute the user-gap upgrade program created from the
+2026-06-02 user-perspective review. Goals 007-012 remain strategic-program
+context; this program focuses on the next upgrade path a user would actually
+feel when adopting a new UDD version.
+
+## Timebox and Team Shape
+
+- Target duration: 10 engineering weeks total, split into five two-week goals.
+- Suggested team: 3-5 engineers across CLI, specs, tests, integration, and
+  documentation.
+- Primary users: product authors, maintainers, test-governance owners, recovery
+  users, and agent operators.
+
+## Objective
+
+Turn the current proof/reporting mismatch and missing user-facing coverage into
+an ordered upgrade pipeline with measurable improvements in status trust, test
+governance, recovery, impact analysis, and agent operation.
+
+## User-Facing Promise
+
+> "Give me the next upgrade program that closes the visible gaps users hit when
+> adopting UDD from a fresh checkout."
+
+## Scope
+
+- Goals 014-018, executed in order unless a roadmap owner explicitly changes the
+  sequence.
+- Source-of-truth use-case, scenario, and E2E-test updates before behavior
+  implementation in every goal.
+- Independent user-perspective review after each goal.
+- Program-level evidence that a fresh checkout is more trustworthy and more
+  useful after each increment.
+
+## Non-Goals
+
+- Rewriting goals 007-012 except to amend direct contradictions discovered
+  during implementation.
+- Treating generated local state as source-controlled proof.
+- Building a visual product UI.
+- Making optional journey files a mandatory duplicate requirement layer.
+
+## Measurables
+
+- Five child goals each deliver one two-week, user-visible upgrade increment.
+- Each child goal includes source-controlled review evidence from its target
+  user perspective.
+- The final program evidence shows status, doctor, repair, trace, impact, and
+  agent evidence agree on proof state and blockers.
+- Fresh-checkout evidence improves from the 2026-06-02 baseline of 1 critical
+  health issue, 34 warnings, 38 stale scenarios, and blocked strategic evidence.
+
+## Ordered Goals
+
+1. `goals/014-status-trust-and-health-baseline.md`
+2. `goals/015-test-governance-upgrade.md`
+3. `goals/016-recovery-workflow-upgrade.md`
+4. `goals/017-change-impact-and-regression-upgrade.md`
+5. `goals/018-agent-operator-upgrade.md`
+
+## Program Upgrade Criteria
+
+- A fresh checkout no longer looks critically unhealthy because generated
+  manifest state is absent.
+- Status, doctor, repair, evidence, trace, and impact commands agree on what is
+  current proof, optional discovery drift, and blocking product debt.
+- Test governance has canonical scenario and E2E proof across inventory,
+  lifecycle, gates, health, and regression prevention.
+- Recovery can guide safe repair work without rewriting user-authored behavior
+  specs.
+- Agent evidence explains why work was chosen, what proof exists, what is
+  blocked, and what should pause for human review.
+
+## Tasks
+
+- [ ] Execute Goal 014 and record a dated user-perspective review.
+- [ ] Execute Goal 015 and record a dated user-perspective review.
+- [ ] Execute Goal 016 and record a dated user-perspective review.
+- [ ] Execute Goal 017 and record a dated user-perspective review.
+- [ ] Execute Goal 018 and record a dated user-perspective review.
+- [ ] Keep each goal on a focused branch or reviewable PR slice.
+- [ ] After each goal, update this master goal if the next goal needs a scoped
+      amendment based on verified findings.
+- [ ] At program end, create a summary report linking every goal, review, and
+      command-evidence artifact.
+
+## Definition of Done
+
+- Goals 014-018 are completed, independently reviewed, and linked from a final
+  program evidence report.
+- Each goal produces user-visible behavior or command output that would justify
+  a version upgrade for its target user perspective.
+- The final fresh-checkout evidence shows no unresolved contradiction between
+  strategic proof reports and default status/health/evidence surfaces.
+
+## Verification Commands
+
+```bash
+./bin/udd status
+./bin/udd lint
+./bin/udd doctor --json
+./bin/udd trace --json
+./bin/udd opencode evidence --json --goal goals/013-user-gap-upgrade-master-goal.md
+npm test -- --run
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if any child goal lacks a dated independent review artifact.
+- Blocks if any child goal skips spec/use-case/scenario updates before
+  implementation.
+- Blocks if generated local state is used as proof of program completion.
+- Blocks if default user-facing commands still contradict source-controlled
+  completion evidence at the end of the program.

--- a/goals/014-status-trust-and-health-baseline.md
+++ b/goals/014-status-trust-and-health-baseline.md
@@ -1,0 +1,104 @@
+# Goal 014: Status Trust and Health Baseline
+
+## Agent Entry
+
+Make the first-run health story trustworthy. A fresh checkout of a healthy UDD
+project must not look blocked because optional generated state is absent or
+because discovery-context drift is reported as canonical product failure.
+
+## Timebox and Team Shape
+
+- Target duration: 2 engineering weeks.
+- Suggested team: 2-4 engineers across CLI diagnostics, trace/status models,
+  tests, and docs.
+- Primary users: maintainers, reviewers, and agents deciding whether a project
+  is safe to work on.
+
+## Objective
+
+Align `udd status`, `udd doctor`, `udd repair`, and agent evidence so they tell
+the same story about healthy source-controlled proof, optional discovery drift,
+generated local state, and real blockers.
+
+## User-Facing Promise
+
+> "Tell me whether this project is actually healthy, and do not scare me with
+> generated-state or optional-discovery warnings unless they matter."
+
+## Scope
+
+- Status and doctor classification for generated manifests, stale journeys,
+  stale scenario result state, and source-controlled proof.
+- Clear separation of canonical source-of-truth blockers from optional
+  discovery drift.
+- Repair dry-run output that ranks safe generated-state refresh separately from
+  user-authored behavior-spec work.
+- Agent evidence updates so next-work recommendations do not over-prioritize
+  generated state when product proof is otherwise sound.
+
+## Non-Goals
+
+- Implementing missing test-governance scenarios.
+- Broad journey migration.
+- Rewriting goals 007-012.
+- Automatically changing user-authored behavior specs.
+
+## Measurables
+
+- Fresh checkout of remote `master` after this goal has zero critical health
+  issues when source-controlled specs are valid.
+- `udd doctor --json` reports generated manifest absence as safe refresh work
+  or advisory state, not a source-of-truth blocker.
+- `udd status --json` separates current proof blockers from optional discovery
+  drift and stale local result state.
+- `udd opencode evidence --json` recommends user-visible work before generated
+  state cleanup unless generated state is truly blocking the requested action.
+- A dated review artifact demonstrates the before/after user story from a fresh
+  shallow clone.
+
+## Tasks
+
+- [ ] Update use cases and scenarios for status trust and generated-state
+      classification before implementation.
+- [ ] Add E2E tests for a fresh checkout with valid source-controlled specs and
+      no manifest.
+- [ ] Add E2E tests for optional journey drift that should not block normal
+      work.
+- [ ] Reclassify generated manifest absence in doctor/status/evidence output.
+- [ ] Update repair dry-run to preserve safe refresh recommendations without
+      labeling healthy projects as critically blocked.
+- [ ] Update status JSON fields so agents can distinguish blocking debt,
+      advisory drift, and local result staleness.
+- [ ] Update docs to explain healthy checkout, generated state, and optional
+      discovery context.
+- [ ] Record before/after evidence under `docs/project/reviews/<date>/`.
+
+## Definition of Done
+
+- A user can clone the repo, install dependencies, and run status/doctor without
+  seeing a false critical blocker from missing generated manifest state.
+- Doctor, status, repair, and evidence commands agree on the classification of
+  generated state and optional journey drift.
+- The review artifact proves the change using a fresh checkout.
+
+## Verification Commands
+
+```bash
+./bin/udd status --json
+./bin/udd doctor --json
+./bin/udd repair --dry-run --json
+./bin/udd opencode evidence --json --goal goals/014-status-trust-and-health-baseline.md
+./bin/udd lint
+npm test -- --run tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
+npm test -- --run tests/e2e/udd/strategic-program/strategic_program_commands.e2e.test.ts
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if a clean valid checkout still reports missing generated manifest
+  state as a critical product-health issue.
+- Blocks if optional journey drift is indistinguishable from canonical
+  source-of-truth failure.
+- Blocks if evidence recommendations send agents to generated-state cleanup
+  before explaining user-visible product work.
+- Blocks if the goal lacks fresh-checkout before/after evidence.

--- a/goals/015-test-governance-upgrade.md
+++ b/goals/015-test-governance-upgrade.md
@@ -1,0 +1,106 @@
+# Goal 015: Test Governance Upgrade
+
+## Agent Entry
+
+Turn test-governance gaps into canonical source-controlled behavior. The goal is
+to let teams see which tests are proof, which are stale, which are reviewed, and
+which findings should block strict gates.
+
+## Timebox and Team Shape
+
+- Target duration: 2 engineering weeks.
+- Suggested team: 3-5 engineers across specs, CLI gates, CI integration, tests,
+  and documentation.
+- Primary users: test-governance owners, maintainers, reviewers, and agents
+  deciding whether behavior is proven.
+
+## Objective
+
+Implement missing test-governance coverage across `track_test_quality`,
+`manage_test_lifecycle`, `enforce_quality_gates`, `monitor_test_health`, and
+`prevent_regression` so teams can adopt UDD gates gradually and credibly.
+
+## User-Facing Promise
+
+> "Show me which tests I can trust, which need review, and which issues should
+> block a merge."
+
+## Scope
+
+- Canonical use-case and feature coverage for test inventory, lifecycle review,
+  quality gates, health monitoring, and regression prevention.
+- Strict and non-strict gate behavior with source-controlled review evidence.
+- Status and evidence output that summarizes governance findings without hiding
+  missing or stale proof.
+- Focused CI or local command examples for adopting gates.
+
+## Non-Goals
+
+- Full historical flake analytics.
+- External dashboard integration.
+- Automatically approving tests.
+- Rewriting existing tests without spec-first changes.
+
+## Measurables
+
+- Each of the five governance use cases has current canonical scenarios and E2E
+  tests for every current outcome this goal promotes out of future/discovery
+  state.
+- Known governance journey gaps are either implemented as canonical scenarios
+  with E2E proof or explicitly reclassified as future scope with source
+  references and a reason.
+- `udd test-scan --json` reports linked, unlinked, orphaned, stubbed, reviewed,
+  stale, and missing proof states with source references.
+- `udd gate test-governance` reports findings without blocking by default.
+- `udd gate test-governance --strict` fails on configured blocking findings and
+  passes on a fixture with reviewed, linked, non-stub proof.
+- Status and agent evidence summarize governance state in terms a reviewer can
+  act on.
+
+## Tasks
+
+- [ ] Update use cases before implementation, moving valid future outcomes into
+      canonical current scenarios where this goal owns them.
+- [ ] Add feature files for missing governance flows: test scan, test status,
+      test review, hook/CI gate behavior, health metrics, and regression
+      detection.
+- [ ] Inventory every existing governance future outcome and journey-referenced
+      missing scenario, then classify it as current implementation scope or
+      explicit future scope before writing CLI code.
+- [ ] Add E2E tests for every new current governance scenario.
+- [ ] Extend test inventory classification with source references and stable
+      JSON fields.
+- [ ] Add source-controlled reviewed-test evidence fixtures.
+- [ ] Prove ignored local cache cannot alter gate outcomes.
+- [ ] Implement strict/non-strict gate fixtures for passing and failing cases.
+- [ ] Update status, evidence, and docs to show governance adoption steps.
+- [ ] Record an independent user-perspective review.
+
+## Definition of Done
+
+- A governance owner can inspect the repo and know which tests are trusted,
+  stale, missing, reviewed, or CI-blocking across every governance outcome this
+  goal keeps in current scope.
+- Strict mode is credible enough to use in CI for configured blocking findings.
+- Non-strict mode remains useful for adoption without blocking all work.
+
+## Verification Commands
+
+```bash
+./bin/udd status --json
+./bin/udd test-scan --json
+./bin/udd gate test-governance
+./bin/udd gate test-governance --strict
+./bin/udd lint
+npm test -- --run tests/e2e/udd/test-governance
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if governance behavior is described only in journeys or docs without
+  canonical scenarios and E2E tests.
+- Blocks if any known governance gap remains neither implemented nor explicitly
+  reclassified as future scope with a reason.
+- Blocks if local ignored cache can change reviewed or blocking gate state.
+- Blocks if strict and non-strict modes are not clearly different.
+- Blocks if status or evidence cannot explain the next governance action.

--- a/goals/016-recovery-workflow-upgrade.md
+++ b/goals/016-recovery-workflow-upgrade.md
@@ -1,0 +1,101 @@
+# Goal 016: Recovery Workflow Upgrade
+
+## Agent Entry
+
+Convert recovery from broad drift detection into a guided, source-controlled
+workflow. A user with a messy UDD project should get a safe diagnosis, a ranked
+repair plan, and explicit refusal for behavior-spec changes that need review.
+
+## Timebox and Team Shape
+
+- Target duration: 2 engineering weeks.
+- Suggested team: 3-5 engineers across diagnostics, repair planning, CLI, test
+  fixtures, and docs.
+- Primary users: developers and agents inheriting partial, stale, or drifted UDD
+  projects.
+
+## Objective
+
+Turn recovery journey drift into canonical use-case, scenario, and E2E coverage
+for diagnosing, planning, applying safe repairs, and reporting unresolved manual
+work.
+
+## User-Facing Promise
+
+> "This UDD project is messy. Tell me what is broken, safely fix what you can,
+> and leave behavior decisions for review."
+
+## Scope
+
+- Canonical scenarios for partial initialization, missing generated state,
+  stale manifests, broken scenario links, missing scenarios, and unsafe behavior
+  spec rewrites.
+- Dry-run and apply-mode repair plans with source references.
+- A recovery backlog or evidence report that ranks manual work without silently
+  creating behavior specs.
+- Fixture coverage for healthy, partial, stale, corrupt, and mixed-version
+  projects.
+
+## Non-Goals
+
+- Fully autonomous recovery of user-authored behavior contracts.
+- Broad Beads workflow implementation beyond recovery backlog/evidence needs.
+- External issue tracker integration.
+- Repairing unrelated repository hygiene.
+
+## Measurables
+
+- Recovery use cases no longer depend on 14 missing journey-referenced scenario
+  files for the current product promise.
+- `udd doctor --json` classifies initialized, partial, stale, corrupt, and
+  drifted fixtures with stable issue types.
+- `udd repair --dry-run --json` produces ranked safe actions and manual-review
+  refusals.
+- `udd repair --apply --json` applies only safe reversible repairs in fixtures.
+- Recovery evidence is reviewable from source-controlled docs or generated
+  command output attached to a review artifact.
+
+## Tasks
+
+- [ ] Update recovery use cases and scenarios before implementation.
+- [ ] Decide which existing recovery journey steps are current scope, future
+      scope, or optional discovery context.
+- [ ] Add canonical scenarios for diagnose, plan, safe apply, manual refusal,
+      final validation, and report generation.
+- [ ] Add fixtures for healthy, partial, stale, corrupt, and mixed-version
+      projects.
+- [ ] Implement or refine recovery issue ranking.
+- [ ] Add dry-run evidence that explains every proposed and refused action.
+- [ ] Add apply-mode tests for safe generated-state and directory repairs.
+- [ ] Add refusal tests proving behavior specs are not rewritten automatically.
+- [ ] Update docs and agent evidence guidance for recovery handoff.
+- [ ] Record an independent user-perspective review.
+
+## Definition of Done
+
+- A user can run doctor and repair commands on representative drift fixtures and
+  understand what will change before anything is written.
+- Safe repairs are applied only when reversible and explicit.
+- Manual behavior-spec decisions are reported as review work, not guessed.
+
+## Verification Commands
+
+```bash
+./bin/udd doctor --json
+./bin/udd repair --dry-run --json
+# Run apply-mode only against controlled fixture or temp-project copies.
+# Do not run apply mode against the reviewer checkout as the proof command.
+npm test -- --run tests/e2e/udd/recovery
+./bin/udd status --json
+./bin/udd lint
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if repair apply mode rewrites user-authored behavior specs.
+- Blocks if apply-mode verification runs against the real reviewer checkout
+  instead of controlled fixtures or temp-project copies.
+- Blocks if current recovery behavior remains represented mainly by missing
+  journey scenario references.
+- Blocks if dry-run output cannot be used to predict apply-mode changes.
+- Blocks if recovery evidence is not durable enough for PR review.

--- a/goals/017-change-impact-and-regression-upgrade.md
+++ b/goals/017-change-impact-and-regression-upgrade.md
@@ -1,0 +1,93 @@
+# Goal 017: Change Impact and Regression Upgrade
+
+## Agent Entry
+
+Connect traceability to concrete regression decisions. A user changing a file
+should see affected objectives, use cases, scenarios, tests, and the exact
+verification commands that prove the change.
+
+## Timebox and Team Shape
+
+- Target duration: 2 engineering weeks.
+- Suggested team: 2-4 engineers across trace graph, status, regression
+  planning, E2E tests, and docs.
+- Primary users: maintainers, reviewers, and agents planning behavior changes.
+
+## Objective
+
+Upgrade trace and impact analysis from project intelligence into a targeted
+regression workflow that recommends verification work for source-controlled
+changes.
+
+## User-Facing Promise
+
+> "Tell me what this change affects and which tests I need to run before I
+> trust it."
+
+## Scope
+
+- Impact output for changed use cases, feature files, tests, goals, and
+  reference-product specs.
+- Recommended verification commands for affected scenarios and tests.
+- Regression markers that distinguish direct impact, adjacent impact, missing
+  proof, and deferred future work.
+- Status/evidence integration so agents can route from changed files to proof
+  obligations.
+
+## Non-Goals
+
+- Full dependency graph for arbitrary application code.
+- Runtime coverage instrumentation.
+- Automatic CI configuration for every repository.
+- Replacing human review judgment.
+
+## Measurables
+
+- `udd impact <path> --json` includes affected objectives, capabilities, use
+  cases, outcomes, scenarios, tests, diagnostics, and recommended commands.
+- Given a changed feature file, UDD identifies the corresponding E2E test and
+  any missing proof.
+- Given a changed use case, UDD identifies all linked scenarios and tests.
+- Given a changed test, UDD identifies the behavior contract it claims to prove.
+- Agent evidence includes targeted verification recommendations for changed
+  files.
+
+## Tasks
+
+- [ ] Update use cases and scenarios for impact-driven regression before
+      implementation.
+- [ ] Extend impact graph output with recommendation fields and confidence
+      levels.
+- [ ] Add tests for changed use-case, feature, test, goal, and reference-product
+      paths.
+- [ ] Add missing-proof diagnostics when an affected scenario lacks an E2E test.
+- [ ] Add command recommendation generation for targeted test runs.
+- [ ] Update status and evidence surfaces to include impact-derived next checks.
+- [ ] Document reviewer workflow for using impact output during PR review.
+- [ ] Record an independent user-perspective review.
+
+## Definition of Done
+
+- A reviewer can run one command for a changed path and see what behavior is
+  affected and which tests should be run.
+- Agents can use changed-file impact to choose verification commands without
+  inventing project-specific routing.
+- Missing proof is explicit and actionable.
+
+## Verification Commands
+
+```bash
+./bin/udd impact specs/use-cases/run_tests.yml --json
+./bin/udd impact specs/features/udd/cli/run_tests.feature --json
+./bin/udd impact tests/e2e/udd/cli/run_tests.e2e.test.ts --json
+./bin/udd opencode evidence --json --goal goals/017-change-impact-and-regression-upgrade.md
+./bin/udd lint
+npm test -- --run tests/e2e/udd
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if impact output cannot recommend concrete verification commands.
+- Blocks if changed tests cannot be traced back to behavior contracts.
+- Blocks if missing proof is hidden behind generic status output.
+- Blocks if agent evidence ignores changed-file impact.

--- a/goals/018-agent-operator-upgrade.md
+++ b/goals/018-agent-operator-upgrade.md
@@ -1,0 +1,100 @@
+# Goal 018: Agent Operator Upgrade
+
+## Agent Entry
+
+Make UDD useful as an agent control surface. Agents should receive shared facts,
+choose meaningful next work, explain proof status, and pause when user review is
+needed.
+
+## Timebox and Team Shape
+
+- Target duration: 2 engineering weeks.
+- Suggested team: 3-5 engineers across shared contracts, agent adapters, CLI,
+  tests, and docs.
+- Primary users: maintainers operating Codex, OpenCode, and future agents over a
+  UDD project.
+
+## Objective
+
+Upgrade agent next-work, issue, status, evidence, and pause/continue decisions
+so adapter-neutral agents can work from shared UDD facts without relying on chat
+history or generated local proof.
+
+## User-Facing Promise
+
+> "Let an agent choose useful UDD work, explain why it chose it, and hand me
+> evidence I can review."
+
+## Scope
+
+- Adapter-neutral JSON contracts for status, next work, issues, verification
+  recommendations, evidence, and pause reasons.
+- Next-work ranking that prioritizes user-visible upgrade work over generated
+  local state unless generated state blocks the requested action.
+- Evidence packages that include proof status, blockers, changed-file impact,
+  and manual-review gates.
+- Codex/OpenCode guidance aligned with shared contracts and no reintroduced
+  goal-command coupling.
+
+## Non-Goals
+
+- Building a full autonomous scheduler.
+- Adding vendor-specific behavior that cannot be represented in shared
+  contracts.
+- Treating generated local state as proof.
+- Automatically resolving human review gates.
+
+## Measurables
+
+- `udd opencode evidence --json` explains goal status, next work, blockers,
+  verification, changed-file impact, and review notes from shared UDD facts.
+- Agent-facing next-work recommendations include reason, user impact, blocking
+  status, suggested files, and verification commands.
+- Generated-state cleanup is ranked below user-visible upgrade work unless it
+  blocks command correctness.
+- Pause reasons are explicit for unsafe repair, missing specs, unresolved
+  review gates, and unverified test claims.
+- Docs show how Codex, OpenCode, and future adapters should consume the same
+  contract.
+
+## Tasks
+
+- [ ] Update use cases and scenarios for agent operator behavior before
+      implementation.
+- [ ] Define or amend shared evidence and next-work contracts.
+- [ ] Add E2E tests for clean, stale, drifted, and review-blocked projects.
+- [ ] Add next-work ranking tests that avoid generated-state over-prioritization.
+- [ ] Integrate impact-derived verification recommendations into evidence.
+- [ ] Add pause/continue decision fields for unsafe recovery and missing proof.
+- [ ] Update Codex/OpenCode docs without coupling behavior to either tool.
+- [ ] Add examples of reviewable agent handoff evidence.
+- [ ] Record an independent user-perspective review.
+
+## Definition of Done
+
+- An agent operator can ask for next work and receive an explanation that a
+  human reviewer can inspect without chat history.
+- Agent evidence points to source-controlled specs, scenarios, tests, reviews,
+  and verification commands.
+- The contract is adapter-neutral and does not make generated local state
+  authoritative.
+
+## Verification Commands
+
+```bash
+./bin/udd opencode evidence --json --goal goals/018-agent-operator-upgrade.md
+./bin/udd status --json
+./bin/udd doctor --json
+./bin/udd impact specs/use-cases/run_tests.yml --json
+./bin/udd lint
+npm test -- --run tests/e2e/opencode tests/e2e/udd/strategic-program
+```
+
+## Reviewer Blocking Criteria
+
+- Blocks if evidence relies on chat history or generated local proof.
+- Blocks if next-work recommendations cannot explain user impact.
+- Blocks if Codex or OpenCode receives behavior that is not represented in the
+  shared contract.
+- Blocks if agents continue through unsafe recovery or unresolved human-review
+  gates without an explicit pause reason.

--- a/goals/README.md
+++ b/goals/README.md
@@ -7,7 +7,8 @@ checks, and prepare focused PRs.
 
 ## How To Use
 
-1. Start with `000-strategic-execution-master-goal.md` for program execution.
+1. Start with `013-user-gap-upgrade-master-goal.md` for the current upgrade
+   program.
 2. Pick the first open implementation goal in numeric order unless a roadmap
    owner selects a specific strategic goal.
 3. Give the agent the goal path.
@@ -16,14 +17,37 @@ checks, and prepare focused PRs.
 
 ## Master Program Goal
 
+- `013-user-gap-upgrade-master-goal.md`: current upgrade program for goals
+  014-018, based on the 2026-06-02 user-gap review of remote `master`.
 - `000-strategic-execution-master-goal.md`: ordered execution program for goals
   007-012, including user-facing success criteria, independent review gates,
-  commit checkpoints, and final end-to-end PR requirements.
+  commit checkpoints, and final end-to-end PR requirements. This remains
+  strategic-program context.
 
-## Current Strategic Portfolio
+## Current Upgrade Portfolio
 
-Goals 007-012 are the current two-week, team-sized execution portfolio. Each is
-intended to be far-reaching enough for multiple engineers, with explicit
+Goals 014-018 are the current two-week, user-visible upgrade portfolio. They
+start from the finding that current strategic proof exists, but a fresh checkout
+still reports stale scenarios, drift, and a missing manifest as user-facing
+friction.
+
+- `014-status-trust-and-health-baseline.md`: align status, doctor, repair, and
+  evidence so a fresh healthy checkout does not look critically blocked by
+  generated local state.
+- `015-test-governance-upgrade.md`: add canonical scenarios and E2E proof for
+  test inventory, lifecycle, gates, health, and regression prevention.
+- `016-recovery-workflow-upgrade.md`: convert recovery journey drift into a
+  safe, reviewable recovery workflow with dry-run/apply proof.
+- `017-change-impact-and-regression-upgrade.md`: connect trace/impact output to
+  concrete regression decisions and verification commands.
+- `018-agent-operator-upgrade.md`: make agent next-work, evidence, and
+  pause/continue decisions usable from shared adapter-neutral contracts.
+
+## Strategic Program Context
+
+Goals 007-012 are the completed strategic-program context that established the
+current proof surfaces. Each was intended to be far-reaching enough for multiple
+engineers, with explicit
 measurables, 10-15 subtasks, verification commands, and reviewer blocking
 criteria.
 
@@ -51,5 +75,7 @@ criteria.
 
 ## Supporting Reviews
 
+- `docs/project/reviews/2026-06-02/user-gap-upgrade-review.md`: user-perspective
+  review of remote `master` that defines the current upgrade portfolio.
 - `docs/project/reviews/2026-05-31-goal-roadmap-review/report.md`: independent
   review that recommends the current strategic portfolio.


### PR DESCRIPTION
## Summary

Defines the next UDD upgrade program from a user-perspective review of remote `master` at `34773dbac1b63d489ce04abd322e5083c2b52325`.

This PR adds:

- `docs/project/reviews/2026-06-02/user-gap-upgrade-review.md`
- `goals/013-user-gap-upgrade-master-goal.md`
- `goals/014-status-trust-and-health-baseline.md`
- `goals/015-test-governance-upgrade.md`
- `goals/016-recovery-workflow-upgrade.md`
- `goals/017-change-impact-and-regression-upgrade.md`
- `goals/018-agent-operator-upgrade.md`
- `goals/README.md` routing updates

## User-Visible Finding

The new review records a contradiction users hit on a fresh checkout: strategic-program proof exists, but default status/evidence surfaces still report 38 stale scenarios, 35 health issues, and a missing manifest as a critical blocker. Goals 014-018 turn that friction into the next ordered upgrade pipeline.

## Adversarial Review

A review agent checked this docs/goals slice from both user and software-engineering perspectives before this PR. Findings were addressed before commit:

- Scoped recovery apply-mode verification to fixtures/temp projects instead of the reviewer checkout.
- Added stronger baseline evidence excerpts and output paths to the review artifact.
- Clarified `goals/README.md` so goals 014-018 are current upgrade work and goals 007-012 are strategic-program context.
- Tightened Goal 015 so known governance gaps must be implemented or explicitly reclassified as future scope.

## Verification

Run locally:

```bash
git diff --cached --check
./bin/udd lint
npm test -- --run tests/e2e/udd/strategic-program/strategic_program_commands.e2e.test.ts tests/e2e/udd/reference-rebuild/task_board_rebuild.e2e.test.ts
```

Results:

- `git diff --cached --check`: passed before commit.
- `./bin/udd lint`: `All specs are valid`.
- Focused Vitest run: 2 files passed, 19 tests passed.

## Review Notes

This PR intentionally packages the upgrade goal pipeline as its own PR before Goal 014 implementation starts, so every subsequent implementation goal can be merged as its own separate PR.
