### PR TITLE
Goal 014: classify advisory health drift separately

### DIFF
--- a/docs/process/recovery-workflow.md
+++ b/docs/process/recovery-workflow.md
@@ -17,12 +17,14 @@ Current command behavior:
 
 - `udd doctor` prints human-readable diagnostic details.
 - `udd doctor --json` emits machine-readable diagnostic details.
-- `udd doctor --strict` exits non-zero when any issue is detected.
+- `udd doctor --strict` exits non-zero when blocking critical or warning issues
+  are detected.
 - `udd health-check --json` emits a concise health envelope for automation.
 
-There is no current `udd doctor --fix`, checkpoint resume, or auto-remediation
-command. Those remain future architecture until a focused implementation slice
-adds and verifies them.
+`udd repair --dry-run --json` can plan safe generated-state repairs without
+writing files. `udd repair --apply --json` exists for controlled fixture or
+temp-project repair proof; do not use apply mode against a valuable checkout
+unless the intended writes have been reviewed.
 
 ## Current Drift Signals
 
@@ -35,13 +37,30 @@ The current diagnostics focus on safe read-only signals, including:
 - manifest references to missing journey or scenario files,
 - orphan scenarios.
 
+Generated-state and optional discovery-context signals are advisory when
+source-controlled specs are otherwise valid:
+
+- missing generated `specs/.udd/manifest.yml`,
+- stale journey hashes,
+- journey-only references to missing scenario files.
+
+Those advisory findings are reported with `severity: "info"` in JSON output and
+do not make `healthy` false. They still appear in summaries so agents and
+reviewers can decide whether to refresh generated metadata or promote optional
+journey steps into current behavior specs.
+
+Blocking health issues remain critical or warning findings. Examples include
+missing source directories, malformed manifests, manifest references to deleted
+files, and orphaned canonical scenario files.
+
 `udd lint` remains the structural spec validator. Recovery diagnostics should be
 read alongside lint and status output rather than treated as a replacement.
 
 ## Recovery Process
 
 1. Run `udd status` to understand the project-wide baseline.
-2. Run `udd doctor --json` or `udd health-check --json` to identify drift.
+2. Run `udd doctor --json` or `udd health-check --json` to identify blocking
+   issues and advisory discovery drift.
 3. Classify each issue as current-slice work, known baseline debt, or future
    follow-up.
 4. Fix source artifacts directly:
@@ -59,8 +78,12 @@ This repository may intentionally contain future or partial journey references
 while salvage work proceeds. A docs-only PR should not try to resolve that
 baseline unless its objective explicitly includes it.
 
-When diagnostics fail because of known baseline drift, record the command output
-and explain why the failure is pre-existing and outside the slice.
+When diagnostics report advisory baseline drift, record the command output only
+when it matters to the slice. Advisory journey metadata is not a reason to block
+normal work by itself.
+
+When diagnostics fail because of blocking baseline drift, record the command
+output and explain why the failure is pre-existing and outside the slice.
 
 ## Future Recovery Architecture
 

--- a/docs/project/reviews/2026-06-03/status-trust-health-baseline.md
+++ b/docs/project/reviews/2026-06-03/status-trust-health-baseline.md
@@ -1,0 +1,186 @@
+# Goal 014 Review: Status Trust And Health Baseline
+
+Date: 2026-06-03
+
+Goal: `goals/014-status-trust-and-health-baseline.md`
+
+Base commit before this implementation:
+`d4c4f6ab1c3314839568bc62244cc9d096796ace`
+
+## Purpose
+
+Review the Goal 014 implementation from user and software-engineering
+perspectives before PR creation.
+
+## Baseline Before This Goal
+
+The user-gap review at
+`docs/project/reviews/2026-06-02/user-gap-upgrade-review.md` captured the
+fresh-checkout baseline at remote head
+`34773dbac1b63d489ce04abd322e5083c2b52325`:
+
+- `udd doctor --json`: `drift-detected`, `healthy: false`, 1 critical issue,
+  34 warnings, total 35 issues.
+- `udd status --json`: 38 stale scenarios.
+- `udd opencode evidence --json --goal goals/000-strategic-execution-master-goal.md`:
+  goal status `blocked`, next recommendation `specs/.udd/manifest.yml`.
+
+After PR #68 merged the upgrade pipeline, the local baseline for Goal 014 was:
+
+- `udd doctor --json`: `drift-detected`, `healthy: false`, 0 critical issues,
+  20 warnings, 34 info findings, total 54 issues.
+- The remaining warnings came from optional journey metadata drift.
+
+## What Changed
+
+- Generated manifest absence is advisory `info` when source-controlled specs are
+  otherwise valid.
+- Stale journey hashes are advisory `info`.
+- Journey-only references to missing scenario files are advisory `info`.
+- Health is now `healthy: true` when there are no critical or warning issues,
+  even if advisory info findings remain.
+- `udd status --json` now includes a compact `health` object with
+  `summary`, `advisory_count`, and `blocking_count`.
+- Agent evidence now ranks current user-visible proof work before generated
+  state cleanup when there are no blocking diagnostics.
+- Recovery documentation explains generated state, optional discovery drift,
+  blocking diagnostics, and safe apply-mode expectations.
+
+## Evidence After This Goal
+
+Commands run locally on branch `codex/status-trust-health-baseline`:
+
+```bash
+./bin/udd doctor --json > /tmp/udd-goal014-doctor.json
+./bin/udd status --json > /tmp/udd-goal014-status.json
+./bin/udd repair --dry-run --json > /tmp/udd-goal014-repair.json
+./bin/udd opencode evidence --json --goal goals/014-status-trust-and-health-baseline.md > /tmp/udd-goal014-evidence.json
+./bin/udd status --doctor > /tmp/udd-goal014-status-doctor.txt
+./bin/udd lint
+npx tsc --noEmit
+npm test -- --run tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
+npm test -- --run tests/lib/agent-integration.test.ts
+npm test -- --run tests/e2e/udd/strategic-program/strategic_program_commands.e2e.test.ts
+```
+
+All commands exited successfully. The `/tmp/udd-goal014-*` files were temporary
+local evidence captures used to build the durable excerpts below.
+
+Review-critical output excerpts:
+
+```json
+{
+  "doctor": {
+    "status": "healthy",
+    "healthy": true,
+    "summary": {
+      "critical": 0,
+      "warning": 0,
+      "info": 54,
+      "total": 54
+    },
+    "conditions": [
+      {
+        "id": "journey_sync",
+        "status": "ok",
+        "message": "Only advisory journey metadata drift detected.",
+        "file": "product/journeys"
+      },
+      {
+        "id": "scenario_links",
+        "status": "ok",
+        "message": "Only advisory journey-linked missing scenarios detected.",
+        "file": "specs/features"
+      }
+    ]
+  },
+  "statusHealth": {
+    "status": "healthy",
+    "healthy": true,
+    "summary": {
+      "critical": 0,
+      "warning": 0,
+      "info": 54,
+      "total": 54
+    },
+    "advisory_count": 54,
+    "blocking_count": 0
+  },
+  "evidence": {
+    "goal": {
+      "path": "goals/014-status-trust-and-health-baseline.md",
+      "status": "in_progress"
+    },
+    "issues": {
+      "critical": 0,
+      "warning": 0,
+      "info": 54,
+      "total": 54
+    },
+    "next": {
+      "recommended": "udd/strategic-program/strategic_program_commands",
+      "reason": "Current-phase scenario result is stale.",
+      "blocking": []
+    }
+  }
+}
+```
+
+`udd status --doctor` excerpt:
+
+```text
+✓ No issues found - project is healthy!
+54 advisory item(s) found; these do not block normal work.
+```
+
+Test results:
+
+- Recovery E2E: 1 test file passed, 43 tests passed.
+- Agent integration unit regression: warning-level diagnostics block agent
+  recommendations before stale scenario work.
+- Strategic-program E2E: 1 test file passed, 6 tests passed.
+- `udd lint`: `All specs are valid`.
+- `npx tsc --noEmit`: passed.
+
+## User-Perspective Review
+
+Passes:
+
+- A maintainer can now run doctor/status and see that optional discovery drift is
+  advisory instead of blocking.
+- A fresh valid project without generated manifest state is classified as
+  healthy while still surfacing advisory metadata refresh work.
+- Agent evidence no longer treats generated metadata as the first blocker when
+  canonical specs are valid.
+
+Remaining user-visible limits:
+
+- Status can still report stale test result state until targeted tests are run.
+  That is expected for Goal 014 because stale test governance is handled by
+  later goals.
+- Advisory counts can be high. The output now classifies them correctly, but
+  later goals should reduce or route them further.
+
+## Software-Engineering Review
+
+Passes:
+
+- The change is narrowly scoped to classification, JSON output, docs, and
+  matching E2E scenarios.
+- Blocking conditions remain blocking for missing source directories, corrupt
+  manifests, manifest references to deleted files, and orphaned canonical
+  scenarios.
+- Apply-mode repair proof remains in controlled tests, not in the reviewer
+  checkout.
+
+Risks to watch:
+
+- Consumers that assumed `healthy === issues.length === 0` must now use
+  `summary.critical + summary.warning` for blocking health. This is intentional
+  and documented.
+- `status --json` gained a `health` object; this is additive and should not
+  break consumers that ignore unknown fields.
+
+## Blocking Concerns
+
+No blocker remains for the Goal 014 PR based on the local evidence above.

--- a/specs/features/udd/recovery/diagnose_project_health.feature
+++ b/specs/features/udd/recovery/diagnose_project_health.feature
@@ -17,6 +17,10 @@ Feature: Diagnose Project Health
 # Success Criteria:
 #   - Doctor JSON includes a status, issue summary, and issue list.
 #   - Health-check JSON reports a healthy boolean and the same issue summary.
+#   - Generated local metadata absence is advisory when source-controlled specs
+#     are otherwise valid.
+#   - Status JSON exposes health classification so agents can distinguish
+#     blocking debt from advisory discovery drift.
 #   - Real initialized temp projects produce structured diagnostics.
 #   - Partially initialized and drifted temp projects report actionable issues.
 #   - Error handling covers partial initialization without crashing.
@@ -25,8 +29,28 @@ Feature: Diagnose Project Health
   Scenario: Report real initialized project diagnostics
     Given a temporary project initialized with "udd init --yes"
     When I run "udd doctor --json"
-    Then the JSON report should identify the project as "drift-detected"
+    Then the JSON report should identify the project as "healthy"
     And the report should include a "missing_scenario" issue
+    And the "missing_scenario" issue should be advisory
+
+  Scenario: Report generated manifest absence as advisory
+    Given a temporary project with valid source-controlled specs but no generated manifest
+    When I run "udd doctor --json"
+    Then the JSON report should identify the project as "healthy"
+    And the report should include a "manifest_missing" issue
+    And the "manifest_missing" issue should be advisory
+
+  Scenario: Expose health classification in status JSON
+    Given a temporary project with valid source-controlled specs but no generated manifest
+    When I run "udd status --json"
+    Then the status JSON health summary should have zero critical issues
+    And the status JSON should identify advisory discovery issues
+
+  Scenario: Keep legacy status doctor aligned with advisory health
+    Given a temporary project with valid source-controlled specs but no generated manifest
+    When I run "udd status --doctor"
+    Then the status doctor output should identify the project as healthy
+    And the status doctor command should not fail
 
   Scenario: Report partial initialization diagnostics
     Given a temporary project with "specs/.udd" but no "product" directory
@@ -37,8 +61,9 @@ Feature: Diagnose Project Health
   Scenario: Report drifted journey diagnostics
     Given a temporary project with a stale journey manifest entry
     When I run "udd doctor --json"
-    Then the JSON report should identify the project as "drift-detected"
+    Then the JSON report should identify the project as "healthy"
     And the report should include a "journey_stale" issue
+    And the "journey_stale" issue should be advisory
 
   Scenario: Report deleted files still referenced by the manifest
     Given a temporary project with manifest entries for deleted journey and scenario files

--- a/specs/use-cases/recover_from_drift.yml
+++ b/specs/use-cases/recover_from_drift.yml
@@ -11,3 +11,8 @@ outcomes:
       - diagnose_project_health
     scenario_paths:
       - udd/recovery/diagnose_project_health
+  - description: Developers and agents can distinguish generated-state and optional-discovery advisories from blocking health issues
+    scenarios:
+      - diagnose_project_health
+    scenario_paths:
+      - udd/recovery/diagnose_project_health

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,8 +1,6 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
-import yaml from "yaml";
+import { analyzeProjectDiagnostics } from "../lib/diagnostics.js";
 import { getProjectStatus } from "../lib/status.js";
 
 export const statusCommand = new Command("status")
@@ -18,163 +16,25 @@ export const statusCommand = new Command("status")
 				console.log(chalk.bold("🔍 Running diagnostics..."));
 				console.log(chalk.dim("=============="));
 
-				const issues: string[] = [];
-				const recommendations: string[] = [];
-
-				// Check 1: Manifest health
-				const manifestPath = path.join(
-					process.cwd(),
-					"specs/.udd/manifest.yml",
+				const report = await analyzeProjectDiagnostics();
+				const blocking = report.issues.filter(
+					(issue) => issue.severity !== "info",
 				);
-				try {
-					await fs.access(manifestPath);
-
-					// Attempt to read and parse manifest to detect malformed YAML
-					try {
-						const manifestContent = await fs.readFile(manifestPath, "utf-8");
-						try {
-							const parsed = yaml.parse(manifestContent);
-							if (!parsed || typeof parsed !== "object") {
-								issues.push(
-									"Manifest file invalid (specs/.udd/manifest.yml) - unexpected structure",
-								);
-								recommendations.push(
-									"Run 'udd sync' to regenerate the manifest",
-								);
-							}
-						} catch (_err) {
-							issues.push(
-								"Manifest YAML malformed or unreadable (specs/.udd/manifest.yml)",
-							);
-							recommendations.push("Run 'udd sync' to regenerate the manifest");
-						}
-					} catch (_err) {
-						issues.push(
-							"Manifest file exists but cannot be read (specs/.udd/manifest.yml)",
-						);
-						recommendations.push("Check file permissions or restore from VCS");
-					}
-				} catch {
-					issues.push("Manifest file missing (specs/.udd/manifest.yml)");
-					recommendations.push("Run 'udd sync' to generate the manifest");
-				}
-
-				// Check 2: Product directory exists
-				if (!status.hasProductDir) {
-					issues.push("No product/ directory found");
-					recommendations.push(
-						"Run 'udd init' to initialize the project structure",
-					);
-				}
-
-				// Check 3: Stale journeys
-				const staleJourneys = Object.values(status.journeys).filter(
-					(j) => j.isStale,
+				const advisory = report.issues.filter(
+					(issue) => issue.severity === "info",
 				);
-				if (staleJourneys.length > 0) {
-					issues.push(
-						`${staleJourneys.length} journey(s) need syncing (hash mismatch)`,
-					);
-					recommendations.push(
-						"Run 'udd sync' to update scenarios from journey changes",
-					);
-				}
-
-				// Check 4: Missing scenarios from journeys
-				const totalMissing = Object.values(status.journeys).reduce(
-					(acc, j) => acc + j.scenariosMissing,
-					0,
-				);
-				if (totalMissing > 0) {
-					issues.push(
-						`${totalMissing} scenario file(s) referenced in journeys not found`,
-					);
-					recommendations.push(
-						"Check journey step references, create missing scenario files",
-					);
-				}
-
-				// Check 5: Orphaned scenarios
-				if (status.orphaned_scenarios.length > 0) {
-					issues.push(
-						`${status.orphaned_scenarios.length} orphaned scenario(s) not linked to use cases`,
-					);
-					recommendations.push(
-						"Link scenarios to use case outcomes or remove unused scenarios",
-					);
-				}
-
-				// Check 6: Failing tests
-				let failingCount = 0;
-				for (const feature of Object.values(status.features)) {
-					for (const scenario of Object.values(feature.scenarios)) {
-						if (scenario.e2e === "failing") failingCount++;
-					}
-				}
-				if (failingCount > 0) {
-					issues.push(`${failingCount} scenario test(s) failing`);
-					recommendations.push(
-						"Run 'npm test' to see failures and fix implementation",
-					);
-				}
-
-				// Check 7: Missing tests
-				let missingCount = 0;
-				for (const feature of Object.values(status.features)) {
-					for (const scenario of Object.values(feature.scenarios)) {
-						if (scenario.e2e === "missing") missingCount++;
-					}
-				}
-				if (missingCount > 0) {
-					issues.push(`${missingCount} scenario(s) missing E2E tests`);
-					recommendations.push(
-						"Create test stubs with 'udd new scenario' or implement tests",
-					);
-				}
-
-				// Check 8: Validation errors in use cases
-				let hasValidationErrors = false;
-				for (const useCase of Object.values(status.use_cases)) {
-					if (useCase.validation_errors.length > 0) {
-						hasValidationErrors = true;
-						break;
-					}
-				}
-				if (hasValidationErrors) {
-					issues.push("Use cases have validation errors");
-					recommendations.push(
-						"Fix use case YAML format - outcomes should be objects with 'description' and 'scenarios'",
-					);
-				}
-
-				// Explicit doctor-mode journey file readability check (independent of status.journeys)
-				if (status.hasProductDir) {
-					try {
-						const journeysDir = path.join(process.cwd(), "product/journeys");
-						const files = await fs.readdir(journeysDir);
-						for (const f of files) {
-							if (!f.endsWith(".md") || f.startsWith("_")) continue;
-							const p = path.join(journeysDir, f);
-							try {
-								await fs.readFile(p, "utf-8");
-							} catch (_err) {
-								issues.push(
-									`Unreadable journey file: ${path.join("product/journeys", f)}`,
-								);
-								recommendations.push(
-									"Check file permissions or restore journey file from VCS/backup",
-								);
-							}
-						}
-					} catch {
-						// ignore - product/journeys may not exist
-					}
-				}
 
 				// Output results
 				console.log();
-				if (issues.length === 0) {
+				if (blocking.length === 0) {
 					console.log(chalk.green("✓ No issues found - project is healthy!"));
+					if (advisory.length > 0) {
+						console.log(
+							chalk.dim(
+								`${advisory.length} advisory item(s) found; these do not block normal work.`,
+							),
+						);
+					}
 					console.log(
 						chalk.dim(
 							"\
@@ -183,9 +43,9 @@ Tip: Run 'udd status' for detailed status view",
 					);
 					process.exitCode = 0;
 				} else {
-					console.log(chalk.red(`Found ${issues.length} issue(s):`));
-					issues.forEach((issue, i) => {
-						console.log(chalk.red(`  ${i + 1}. ${issue}`));
+					console.log(chalk.red(`Found ${blocking.length} blocking issue(s):`));
+					blocking.forEach((issue, i) => {
+						console.log(chalk.red(`  ${i + 1}. ${issue.message}`));
 					});
 
 					console.log(
@@ -194,8 +54,8 @@ Tip: Run 'udd status' for detailed status view",
 Recommendations:",
 						),
 					);
-					recommendations.forEach((rec, i) => {
-						console.log(chalk.cyan(`  ${i + 1}. ${rec}`));
+					blocking.forEach((issue, i) => {
+						console.log(chalk.cyan(`  ${i + 1}. ${issue.recommendation}`));
 					});
 
 					process.exitCode = 1;
@@ -205,7 +65,24 @@ Recommendations:",
 			}
 
 			if (options.json) {
-				console.log(JSON.stringify(status, null, 2));
+				const diagnostics = await analyzeProjectDiagnostics();
+				console.log(
+					JSON.stringify(
+						{
+							...status,
+							health: {
+								status: diagnostics.status,
+								healthy: diagnostics.healthy,
+								summary: diagnostics.summary,
+								advisory_count: diagnostics.summary.info,
+								blocking_count:
+									diagnostics.summary.critical + diagnostics.summary.warning,
+							},
+						},
+						null,
+						2,
+					),
+				);
 			} else {
 				console.log(chalk.bold("Project Status"));
 				console.log(chalk.dim("=============="));

--- a/src/lib/agent-integration.ts
+++ b/src/lib/agent-integration.ts
@@ -84,7 +84,6 @@ export interface AgentEvidencePackage {
 const AUTO_FIXABLE_TYPES = new Set<DiagnosticIssue["type"]>([
 	"manifest_missing",
 	"journey_stale",
-	"missing_scenario",
 ]);
 
 function isCurrentPhaseScenario(
@@ -191,7 +190,7 @@ export function recommendNextAgentWork(
 	now = new Date(),
 ): AgentWorkRecommendation {
 	const issues = buildAgentIssueList(report);
-	const blocking = issues.filter((issue) => issue.severity === "critical");
+	const blocking = issues.filter((issue) => issue.severity !== "info");
 
 	if (blocking.length > 0) {
 		const firstBlocker = blocking[0];

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -158,10 +158,10 @@ async function readManifest(
 		issues.push(
 			issue(
 				"manifest_missing",
-				"critical",
+				"info",
 				"specs/.udd/manifest.yml",
-				"Manifest file is missing.",
-				"Run 'udd init' or 'udd sync' to create the manifest.",
+				"Generated manifest file is missing.",
+				"Run 'udd sync' when generated journey metadata is needed.",
 			),
 		);
 		return null;
@@ -261,10 +261,10 @@ async function inspectJourneys(
 			issues.push(
 				issue(
 					"journey_stale",
-					"warning",
+					"info",
 					relJourneyPath,
 					`Journey '${key}' has changed since the manifest was written.`,
-					"Run 'udd sync' after reviewing the journey changes.",
+					"Run 'udd sync' if this optional journey discovery context should refresh generated metadata.",
 				),
 			);
 		}
@@ -284,10 +284,10 @@ async function inspectJourneys(
 				issues.push(
 					issue(
 						"missing_scenario",
-						"warning",
+						"info",
 						scenarioPath,
 						`Journey '${key}' references a missing scenario.`,
-						"Create the scenario or update the journey reference.",
+						"Create the scenario only if this optional journey step is promoted to current source-of-truth scope.",
 					),
 				);
 			}
@@ -403,6 +403,9 @@ export async function analyzeProjectDiagnostics(
 	};
 	const hasIssue = (type: DiagnosticIssueType) =>
 		issues.some((item) => item.type === type);
+	const hasBlockingIssue = (type: DiagnosticIssueType) =>
+		issues.some((item) => item.type === type && item.severity !== "info");
+	const healthy = summary.critical === 0 && summary.warning === 0;
 	const conditions: DiagnosticReport["conditions"] = [
 		{
 			id: "initialized",
@@ -453,18 +456,22 @@ export async function analyzeProjectDiagnostics(
 		},
 		{
 			id: "journey_sync",
-			status: hasIssue("journey_stale") ? "stale" : "ok",
-			message: hasIssue("journey_stale")
+			status: hasBlockingIssue("journey_stale") ? "stale" : "ok",
+			message: hasBlockingIssue("journey_stale")
 				? "One or more journeys changed after manifest generation."
-				: "Journey hashes match the manifest.",
+				: hasIssue("journey_stale")
+					? "Only advisory journey metadata drift detected."
+					: "Journey hashes match the manifest.",
 			file: "product/journeys",
 		},
 		{
 			id: "scenario_links",
-			status: hasIssue("missing_scenario") ? "drifted" : "ok",
-			message: hasIssue("missing_scenario")
+			status: hasBlockingIssue("missing_scenario") ? "drifted" : "ok",
+			message: hasBlockingIssue("missing_scenario")
 				? "One or more scenario links point to missing files."
-				: "Scenario links resolve.",
+				: hasIssue("missing_scenario")
+					? "Only advisory journey-linked missing scenarios detected."
+					: "Scenario links resolve.",
 			file: "specs/features",
 		},
 		{
@@ -485,8 +492,8 @@ export async function analyzeProjectDiagnostics(
 	];
 
 	return {
-		status: issues.length === 0 ? "healthy" : "drift-detected",
-		healthy: issues.length === 0,
+		status: healthy ? "healthy" : "drift-detected",
+		healthy,
 		lastCheck: new Date().toISOString(),
 		summary,
 		conditions,

--- a/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
+++ b/tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
@@ -51,6 +51,71 @@ function issueTypes(report: Record<string, unknown>): string[] {
 	return (issues as Array<{ type: string }>).map((issue) => issue.type);
 }
 
+function issueSeverities(
+	report: Record<string, unknown>,
+): Record<string, string> {
+	const issues = report.issues;
+	expect(Array.isArray(issues)).toBe(true);
+	return Object.fromEntries(
+		(issues as Array<{ type: string; severity: string }>).map((issue) => [
+			issue.type,
+			issue.severity,
+		]),
+	);
+}
+
+async function writeValidSourceProjectWithoutManifest() {
+	await fs.mkdir(path.join(projectDir, "product/journeys"), {
+		recursive: true,
+	});
+	await fs.mkdir(path.join(projectDir, "specs/features/example"), {
+		recursive: true,
+	});
+	await fs.mkdir(path.join(projectDir, "specs/use-cases"), {
+		recursive: true,
+	});
+	await fs.writeFile(
+		path.join(projectDir, "product/journeys/example.md"),
+		[
+			"# Journey: Example",
+			"",
+			"**Actor:** User",
+			"**Goal:** Capture optional discovery context",
+			"",
+			"## Steps",
+			"",
+			"1. Optional future step -> `specs/features/example/future.feature`",
+			"",
+		].join("\n"),
+	);
+	await fs.writeFile(
+		path.join(projectDir, "specs/features/example/_feature.yml"),
+		"id: example\nname: Example\nsummary: Example feature\nphase: 3\n",
+	);
+	await fs.writeFile(
+		path.join(projectDir, "specs/features/example/current.feature"),
+		"@phase:3\nFeature: Current example\n\n  Scenario: Current example\n    Given current behavior exists\n",
+	);
+	await fs.writeFile(
+		path.join(projectDir, "specs/use-cases/example.yml"),
+		[
+			"id: example",
+			"name: Example",
+			"summary: Example source-controlled behavior",
+			"phase: 3",
+			"actors:",
+			"  - user",
+			"outcomes:",
+			"  - description: Current behavior is linked from source-controlled specs",
+			"    scenarios:",
+			"      - current",
+			"    scenario_paths:",
+			"      - example/current",
+			"",
+		].join("\n"),
+	);
+}
+
 describeFeature(feature, ({ Scenario }) => {
 	Scenario(
 		"Report real initialized project diagnostics",
@@ -68,18 +133,130 @@ describeFeature(feature, ({ Scenario }) => {
 				output = await runUddInProject("doctor --json");
 			});
 
-			Then(
-				'the JSON report should identify the project as "drift-detected"',
-				() => {
-					const report = parsedJson<{ status: string; healthy: boolean }>();
-					expect(report.status).toBe("drift-detected");
-					expect(report.healthy).toBe(false);
+			Then('the JSON report should identify the project as "healthy"', () => {
+				const report = parsedJson<{ status: string; healthy: boolean }>();
+				expect(report.status).toBe("healthy");
+				expect(report.healthy).toBe(true);
+			});
+
+			And('the report should include a "missing_scenario" issue', () => {
+				expect(issueTypes(parsedJson())).toContain("missing_scenario");
+			});
+
+			And('the "missing_scenario" issue should be advisory', async () => {
+				try {
+					expect(issueSeverities(parsedJson()).missing_scenario).toBe("info");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Report generated manifest absence as advisory",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with valid source-controlled specs but no generated manifest",
+				async () => {
+					await startProject();
+					await writeValidSourceProjectWithoutManifest();
 				},
 			);
 
-			And('the report should include a "missing_scenario" issue', async () => {
+			When('I run "udd doctor --json"', async () => {
+				output = await runUddInProject("doctor --json");
+			});
+
+			Then('the JSON report should identify the project as "healthy"', () => {
+				const report = parsedJson<{ status: string; healthy: boolean }>();
+				expect(report.status).toBe("healthy");
+				expect(report.healthy).toBe(true);
+			});
+
+			And('the report should include a "manifest_missing" issue', () => {
+				expect(issueTypes(parsedJson())).toContain("manifest_missing");
+			});
+
+			And('the "manifest_missing" issue should be advisory', async () => {
 				try {
-					expect(issueTypes(parsedJson())).toContain("missing_scenario");
+					expect(issueSeverities(parsedJson()).manifest_missing).toBe("info");
+				} finally {
+					await cleanupProject();
+				}
+			});
+		},
+	);
+
+	Scenario(
+		"Expose health classification in status JSON",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with valid source-controlled specs but no generated manifest",
+				async () => {
+					await startProject();
+					await writeValidSourceProjectWithoutManifest();
+				},
+			);
+
+			When('I run "udd status --json"', async () => {
+				output = await runUddInProject("status --json");
+			});
+
+			Then(
+				"the status JSON health summary should have zero critical issues",
+				() => {
+					const report = parsedJson<{
+						health: { summary: { critical: number }; blocking_count: number };
+					}>();
+					expect(report.health.summary.critical).toBe(0);
+					expect(report.health.blocking_count).toBe(0);
+				},
+			);
+
+			And(
+				"the status JSON should identify advisory discovery issues",
+				async () => {
+					try {
+						const report = parsedJson<{
+							health: { summary: { info: number }; advisory_count: number };
+						}>();
+						expect(report.health.summary.info).toBeGreaterThan(0);
+						expect(report.health.advisory_count).toBeGreaterThan(0);
+					} finally {
+						await cleanupProject();
+					}
+				},
+			);
+		},
+	);
+
+	Scenario(
+		"Keep legacy status doctor aligned with advisory health",
+		({ Given, When, Then, And }) => {
+			Given(
+				"a temporary project with valid source-controlled specs but no generated manifest",
+				async () => {
+					await startProject();
+					await writeValidSourceProjectWithoutManifest();
+				},
+			);
+
+			When('I run "udd status --doctor"', async () => {
+				output = await runUddInProject("status --doctor");
+			});
+
+			Then(
+				"the status doctor output should identify the project as healthy",
+				() => {
+					expect(output.stdout).toContain("project is healthy");
+					expect(output.stdout).toContain("advisory item(s)");
+				},
+			);
+
+			And("the status doctor command should not fail", async () => {
+				try {
+					expect(output.code ?? 0).toBe(0);
 				} finally {
 					await cleanupProject();
 				}
@@ -178,17 +355,19 @@ describeFeature(feature, ({ Scenario }) => {
 				output = await runUddInProject("doctor --json");
 			});
 
-			Then(
-				'the JSON report should identify the project as "drift-detected"',
-				() => {
-					const report = parsedJson<{ status: string }>();
-					expect(report.status).toBe("drift-detected");
-				},
-			);
+			Then('the JSON report should identify the project as "healthy"', () => {
+				const report = parsedJson<{ status: string; healthy: boolean }>();
+				expect(report.status).toBe("healthy");
+				expect(report.healthy).toBe(true);
+			});
 
-			And('the report should include a "journey_stale" issue', async () => {
+			And('the report should include a "journey_stale" issue', () => {
+				expect(issueTypes(parsedJson())).toContain("journey_stale");
+			});
+
+			And('the "journey_stale" issue should be advisory', async () => {
 				try {
-					expect(issueTypes(parsedJson())).toContain("journey_stale");
+					expect(issueSeverities(parsedJson()).journey_stale).toBe("info");
 				} finally {
 					await cleanupProject();
 				}

--- a/tests/lib/agent-integration.test.ts
+++ b/tests/lib/agent-integration.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "vitest";
+import { recommendNextAgentWork } from "../../src/lib/agent-integration.js";
+import type { DiagnosticReport } from "../../src/lib/diagnostics.js";
+import type { ProjectStatus } from "../../src/lib/status.js";
+
+test("agent next work treats warning diagnostics as blockers", () => {
+	const status: ProjectStatus = {
+		git: {
+			branch: "test",
+			clean: true,
+			modified: 0,
+			staged: 0,
+			untracked: 0,
+		},
+		current_phase: 3,
+		phases: { "3": "Agent Integration" },
+		active_features: ["udd/example"],
+		features: {
+			"udd/example": {
+				path: "udd/example",
+				scenarios: {
+					current: {
+						e2e: "stale",
+						isDeferred: false,
+						phase: 3,
+					},
+				},
+				requirements: {},
+			},
+		},
+		use_cases: {},
+		orphaned_scenarios: [],
+		journeys: {},
+		hasProductDir: true,
+	};
+	const report: DiagnosticReport = {
+		status: "drift-detected",
+		healthy: false,
+		lastCheck: "2026-06-03T00:00:00.000Z",
+		summary: {
+			critical: 0,
+			warning: 1,
+			info: 0,
+			total: 1,
+		},
+		conditions: [],
+		issues: [
+			{
+				id: "warning:orphan_scenario:specs/features/orphan.feature",
+				severity: "warning",
+				type: "orphan_scenario",
+				file: "specs/features/orphan.feature",
+				message: "Scenario is not referenced by source-of-truth artifacts.",
+				recommendation: "Link the scenario to a use case outcome or remove it.",
+			},
+		],
+	};
+
+	const next = recommendNextAgentWork(
+		status,
+		report,
+		new Date("2026-06-03T00:00:00.000Z"),
+	);
+
+	expect(next.recommended).toBe("specs/features/orphan.feature");
+	expect(next.blocking).toHaveLength(1);
+	expect(next.blocking[0]).toMatchObject({
+		severity: "warning",
+		type: "orphan_scenario",
+	});
+});


### PR DESCRIPTION
## Goal

Implements `goals/014-status-trust-and-health-baseline.md`: make default status/doctor output match proved project reality by separating blocking product-proof health issues from advisory generated-state and optional discovery drift.

## What changed

- Updated recovery use-case and BDD coverage before implementation for status/doctor trust behavior.
- Reclassified generated manifest absence, stale optional journey metadata, and journey-linked missing scenarios as advisory `info` diagnostics.
- Reworked `udd status --doctor` to use the shared diagnostics model instead of duplicate legacy checks.
- Added `status --json` health classification with `advisory_count` and `blocking_count`.
- Kept agent next-work routing from treating advisory missing scenarios as auto-fixable blocking work, while still blocking on warning/critical issues.
- Added the independent user-perspective review artifact at `docs/project/reviews/2026-06-03/status-trust-health-baseline.md`.

## Review evidence

Independent review agent found four concerns before publication:

1. warning diagnostics could be ignored by agent evidence routing;
2. legacy `udd status --doctor` still treated advisory drift as failure;
3. the review artifact needed stronger command evidence;
4. doctor condition text overstated scenario-link health when advisory journey-linked missing scenarios existed.

All four were addressed in this branch. The review artifact now records the base SHA, command evidence, and corrected user-facing interpretation.

## Verification

Local branch verification:

```bash
./bin/udd lint
git diff --check
npx tsc --noEmit
npm test -- --run tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts
npm test -- --run tests/e2e/udd/strategic-program/strategic_program_commands.e2e.test.ts
npm test -- --run tests/lib/agent-integration.test.ts
npm test -- --run tests/e2e/udd/recovery/diagnose_project_health.e2e.test.ts tests/lib/agent-integration.test.ts tests/e2e/udd/strategic-program/strategic_program_commands.e2e.test.ts
npm test -- --run tests/lib/codex-tooling.test.ts tests/e2e/udd/cli/codex_hooks.e2e.test.ts
./bin/udd doctor --json
./bin/udd status --json
./bin/udd status --doctor
./bin/udd opencode evidence --json --goal goals/014-status-trust-and-health-baseline.md
```

Results:

- `udd lint`: pass
- TypeScript: pass
- focused recovery tests: 43 pass
- strategic program tests: 6 pass
- agent integration regression: 1 pass
- combined regression run: 50 pass
- Codex hook tests: 11 pass
- current branch `udd doctor --json`: healthy, `critical: 0`, `warning: 0`, `info: 54`
- current branch `udd status --doctor`: exits 0 and reports advisory items as non-blocking

Fresh checkout proof from a shallow clone of this branch:

```json
{
  "doctor": {
    "status": "healthy",
    "healthy": true,
    "summary": {
      "critical": 0,
      "warning": 0,
      "info": 35,
      "total": 35
    }
  },
  "statusHealth": {
    "status": "healthy",
    "healthy": true,
    "summary": {
      "critical": 0,
      "warning": 0,
      "info": 35,
      "total": 35
    },
    "advisory_count": 35,
    "blocking_count": 0
  }
}
```
